### PR TITLE
midi_node : changing m_parent to store it as pointer (like in generic_node)

### DIFF
--- a/OSSIA/ossia-python/examples/ossia-python_example.py
+++ b/OSSIA/ossia-python/examples/ossia-python_example.py
@@ -273,11 +273,30 @@ for data in midi_devices:
 remote_midi_device = ossia.MidiDevice("remoteMidiDevice", midi_devices[0])
 
 # iterate on remote MIDI device namespace
-print("\nREMOTE MIDI DEVICE NAMESPACE")
-iterate_on_children(remote_midi_device.root_node)
+#print("\nREMOTE MIDI DEVICE NAMESPACE")
+#iterate_on_children(remote_midi_device.root_node)
 
+# create a message queue to focus on a MIDI parameter
+remote_midi_messageq = ossia.MessageQueue(remote_midi_device)
+remote_midi_parameter = remote_midi_device.find_node("/1/control/32").parameter
+remote_midi_messageq.register(remote_midi_parameter)
 
 # MAIN LOOP
-# wait and use Ossia Score to change the value remotely
+print("\nMAIN LOOP ...")
+# observe all local device messages
+local_device_messageq = ossia.GlobalMessageQueue(local_device)
+
+# wait and change the value remotely
 while True:
-  time.sleep(0.1)
+
+  message = remote_midi_messageq.pop()
+  if message != None:
+    parameter, value = message
+    print("remote_midi_messageq : " +  str(parameter.node) + " " + str(value))
+
+  message = local_device_messageq.pop()
+  if(message != None):
+    parameter, value = message
+    print("local_device_messageq : " +  str(parameter.node) + " " + str(value))
+
+  time.sleep(0.01)

--- a/OSSIA/ossia-python/ossia_python.cpp
+++ b/OSSIA/ossia-python/ossia_python.cpp
@@ -894,6 +894,7 @@ PYBIND11_MODULE(ossia_python, m)
       .def(py::init<ossia_osc_device&>())
       .def(py::init<ossia_oscquery_device&>())
       .def(py::init<ossia_minuit_device&>())
+      .def(py::init<ossia_midi_device&>())
       .def("register", [] (ossia::message_queue& mq, ossia::net::parameter_base& p) {
     mq.reg(p);
   })
@@ -910,12 +911,12 @@ PYBIND11_MODULE(ossia_python, m)
      return py::none{};
   });
 
-
   py::class_<ossia::global_message_queue>(m, "GlobalMessageQueue")
       .def(py::init<ossia_local_device&>())
       .def(py::init<ossia_osc_device&>())
       .def(py::init<ossia_oscquery_device&>())
       .def(py::init<ossia_minuit_device&>())
+      .def(py::init<ossia_midi_device&>())
       .def("pop", [] (ossia::global_message_queue& mq) -> py::object {
      ossia::received_value v;
      bool res = mq.try_dequeue(v);

--- a/OSSIA/ossia/network/midi/midi_device.cpp
+++ b/OSSIA/ossia/network/midi/midi_device.cpp
@@ -12,7 +12,7 @@ namespace net
 namespace midi
 {
 midi_device::midi_device(std::unique_ptr<protocol_base> prot)
-    : ossia::net::device_base{std::move(prot)}, midi_node{*this, *this}
+    : ossia::net::device_base{std::move(prot)}, midi_node{*this}
 {
   m_protocol->set_device(*this);
 }

--- a/OSSIA/ossia/network/midi/midi_node.cpp
+++ b/OSSIA/ossia/network/midi/midi_node.cpp
@@ -33,7 +33,12 @@ midi_node::~midi_node()
 }
 
 midi_node::midi_node(midi_device& aDevice, node_base& aParent)
-    : m_device{aDevice}, m_parent{aParent}
+    : m_device{aDevice}, m_parent{&aParent}
+{
+}
+
+midi_node::midi_node(midi_device& aDevice)
+    : m_device{aDevice}
 {
 }
 
@@ -44,7 +49,7 @@ device_base& midi_node::get_device() const
 
 node_base* midi_node::get_parent() const
 {
-  return &m_parent;
+  return m_parent;
 }
 
 node_base& midi_node::set_name(std::string)

--- a/OSSIA/ossia/network/midi/midi_node.hpp
+++ b/OSSIA/ossia/network/midi/midi_node.hpp
@@ -14,7 +14,7 @@ class OSSIA_EXPORT midi_node : public ossia::net::node_base
 {
 protected:
   midi_device& m_device;
-  node_base& m_parent;
+  node_base* m_parent{};
   std::unique_ptr<parameter_base> m_parameter;
 
 public:
@@ -23,6 +23,7 @@ public:
       = ossia::ptr_container<ossia::net::node_base>::const_iterator;
   ~midi_node();
   midi_node(midi_device& aDevice, ossia::net::node_base& aParent);
+  midi_node(midi_device& aDevice);
 
   device_base& get_device() const final override;
   node_base* get_parent() const final override;


### PR DESCRIPTION
to have a midi_device constructor with no parent node (as generic_device)

this is needed because I have a crash in parameter.cpp due to the fact the parent was never null for midi_device node : https://github.com/OSSIA/libossia/blob/7af8a40d9bbaf89463666c0fa2f1617b118b2b64/OSSIA/ossia/network/base/parameter.cpp#L34