### PR TITLE
Joystick Protocol Integration

### DIFF
--- a/CMake/OssiaConfiguration.cmake
+++ b/CMake/OssiaConfiguration.cmake
@@ -41,6 +41,7 @@ option(OSSIA_PROTOCOL_WEBSOCKETS "Enable WebSockets protocol" OFF) # Requires Qt
 option(OSSIA_PROTOCOL_SERIAL "Enable Serial port protocol" OFF) # Requires Qt
 option(OSSIA_PROTOCOL_PHIDGETS "Enable Phidgets protocol" OFF) # Requires Phidgets library
 option(OSSIA_PROTOCOL_LEAPMOTION "Enable Leapmotion protocol" OFF) # Requires LeapMotion Orion library
+option(OSSIA_PROTOCOL_JOYSTICK "Enable Joystick protocol" OFF)  # Requires SDL2 library
 option(OSSIA_DISABLE_QT_PLUGIN "Disable building of a Qt plugin" OFF)
 option(OSSIA_DNSSD "Enable DNSSD support" ON)
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/CMake;${PROJECT_SOURCE_DIR}/CMake/cmake-modules;")

--- a/OSSIA/CMakeLists.txt
+++ b/OSSIA/CMakeLists.txt
@@ -111,6 +111,13 @@ if(OSSIA_PROTOCOL_LEAPMOTION)
   endif()
 endif()
 
+if(OSSIA_PROTOCOL_JOYSTICK)
+  find_package(SDL2)
+  if(NOT SDL2_FOUND)
+    set(OSSIA_PROTOCOL_JOYSTICK FALSE)
+  endif()
+endif()
+
 if (OSSIA_CI)
   if ( $ENV{TRAVIS} MATCHES true )
     message(STATUS "We're building on Travis, SHA: $ENV{TRAVIS_COMMIT}, TAG: $ENV{TRAVIS_TAG}")
@@ -209,6 +216,14 @@ if(OSSIA_PROTOCOL_LEAPMOTION)
   target_link_libraries(ossia PUBLIC LeapMotion)
   set(OSSIA_PROTOCOLS ${OSSIA_PROTOCOLS} LeapMotion)
 endif()
+
+if(OSSIA_PROTOCOL_JOYSTICK)
+  target_sources(ossia PRIVATE ${OSSIA_JOYSTICK_SRCS} ${OSSIA_JOYSTICK_HEADERS})
+  target_include_directories(ossia PRIVATE ${SDL2_INCLUDE_DIRS})
+  target_link_libraries(ossia PRIVATE SDL2)
+  set(OSSIA_PROTOCOLS ${OSSIA_PROTOCOLS} Joystick)
+endif()
+
 # Additional features
 if(OSSIA_C)
   target_sources(ossia PRIVATE ${OSSIA_C_HEADERS} ${OSSIA_C_SRCS})

--- a/OSSIA/ossia-config.hpp.in
+++ b/OSSIA/ossia-config.hpp.in
@@ -11,6 +11,7 @@
 #cmakedefine OSSIA_PROTOCOL_SERIAL
 #cmakedefine OSSIA_PROTOCOL_PHIDGETS
 #cmakedefine OSSIA_PROTOCOL_LEAPMOTION
+#cmakedefine OSSIA_PROTOCOL_JOYSTICK
 
 // Additional features
 #cmakedefine OSSIA_DNSSD

--- a/OSSIA/ossia/network/generic/generic_device.cpp
+++ b/OSSIA/ossia/network/generic/generic_device.cpp
@@ -14,16 +14,16 @@ generic_device::generic_device(std::string name)
     : device_base{std::make_unique<multiplex_protocol>()}
     , generic_node{std::move(name), *this}
 {
-  m_protocol->set_device(*this);
   m_capabilities.change_tree = true;
+  m_protocol->set_device(*this);
 }
 
 generic_device::generic_device(
     std::unique_ptr<ossia::net::protocol_base> protocol, std::string name)
     : device_base(std::move(protocol)), generic_node(std::move(name), *this)
 {
-  m_protocol->set_device(*this);
   m_capabilities.change_tree = true;
+  m_protocol->set_device(*this);
 }
 
 generic_device::~generic_device()

--- a/OSSIA/ossia/network/joystick/device_parameter.cpp
+++ b/OSSIA/ossia/network/joystick/device_parameter.cpp
@@ -1,0 +1,104 @@
+
+#include "device_parameter.hpp"
+
+
+namespace ossia
+{
+namespace net
+{
+
+    device_parameter::device_parameter(
+        net::node_base& node,
+        const val_type type,
+        const bounding_mode bounding,
+        const access_mode access,
+        const domain domain)
+        : net::parameter_base{node},
+            m_current_value{},
+            m_type{type},
+            m_bounding{bounding},
+            m_access{access},
+            m_domain{domain}
+    {
+        set_repetition_filter(repetition_filter::ON);
+    }
+
+    device_parameter::~device_parameter()
+    {
+
+    }
+
+    void device_parameter::device_value_change_event(const ossia::value& val)
+    {
+        if (val.valid()) {
+            m_current_value = val;
+            get_protocol().push(*this); 
+        }
+    }
+
+    void device_parameter::pull_value()
+    {
+        get_protocol().pull(*this);
+    }
+
+    ossia::value device_parameter::value() const
+    {
+        return m_current_value;
+    }
+
+    net::parameter_base& device_parameter::push_value(const ossia::value& val)  
+    {
+        set_value(val);
+        get_protocol().push(*this); 
+        return *this; 
+    }
+
+    net::parameter_base& device_parameter::push_value(ossia::value&& val) 
+    { 
+        return push_value(val); 
+    }
+
+    net::parameter_base& device_parameter::push_value() 
+    {     
+        get_protocol().push(*this); 
+        return *this; 
+    }
+
+    net::parameter_base& device_parameter::set_value(const ossia::value& val) 
+    {
+        if (val.valid()) {
+            m_current_value = val;
+            send(val);
+            device_update_value();
+        }
+        
+        return *this;
+    }
+
+    net::parameter_base& device_parameter::set_value(ossia::value&& val)
+    {
+        return set_value(val);
+    }
+
+    val_type device_parameter::get_value_type() const 
+    {
+        return m_type;
+    }
+
+    access_mode device_parameter::get_access() const 
+    {   
+        return m_access;
+    }
+
+    const domain& device_parameter::get_domain() const  
+    {
+        return m_domain; 
+    }
+
+    bounding_mode device_parameter::get_bounding() const 
+    {   
+        return m_bounding;
+    }
+
+}
+}

--- a/OSSIA/ossia/network/joystick/device_parameter.cpp
+++ b/OSSIA/ossia/network/joystick/device_parameter.cpp
@@ -1,104 +1,97 @@
 
 #include "device_parameter.hpp"
 
-
-namespace ossia
-{
-namespace net
+namespace ossia::net
 {
 
-    device_parameter::device_parameter(
-        net::node_base& node,
-        const val_type type,
-        const bounding_mode bounding,
-        const access_mode access,
-        const domain domain)
-        : net::parameter_base{node},
-            m_current_value{},
-            m_type{type},
-            m_bounding{bounding},
-            m_access{access},
-            m_domain{domain}
-    {
-        set_repetition_filter(repetition_filter::ON);
-    }
+device_parameter::device_parameter(
+    net::node_base& node, const val_type type, const bounding_mode bounding,
+    const access_mode access, const domain domain)
+    : net::parameter_base{node}
+    , m_current_value{}
+    , m_type{type}
+    , m_bounding{bounding}
+    , m_access{access}
+    , m_domain{domain}
+{
+  set_repetition_filter(repetition_filter::ON);
+}
 
-    device_parameter::~device_parameter()
-    {
+device_parameter::~device_parameter()
+{
+}
 
-    }
+void device_parameter::device_value_change_event(const ossia::value& val)
+{
+  if (val.valid())
+  {
+    m_current_value = val;
+    get_protocol().push(*this);
+  }
+}
 
-    void device_parameter::device_value_change_event(const ossia::value& val)
-    {
-        if (val.valid()) {
-            m_current_value = val;
-            get_protocol().push(*this); 
-        }
-    }
+void device_parameter::pull_value()
+{
+  get_protocol().pull(*this);
+}
 
-    void device_parameter::pull_value()
-    {
-        get_protocol().pull(*this);
-    }
+ossia::value device_parameter::value() const
+{
+  return m_current_value;
+}
 
-    ossia::value device_parameter::value() const
-    {
-        return m_current_value;
-    }
+net::parameter_base& device_parameter::push_value(const ossia::value& val)
+{
+  set_value(val);
+  get_protocol().push(*this);
+  return *this;
+}
 
-    net::parameter_base& device_parameter::push_value(const ossia::value& val)  
-    {
-        set_value(val);
-        get_protocol().push(*this); 
-        return *this; 
-    }
+net::parameter_base& device_parameter::push_value(ossia::value&& val)
+{
+  return push_value(val);
+}
 
-    net::parameter_base& device_parameter::push_value(ossia::value&& val) 
-    { 
-        return push_value(val); 
-    }
+net::parameter_base& device_parameter::push_value()
+{
+  get_protocol().push(*this);
+  return *this;
+}
 
-    net::parameter_base& device_parameter::push_value() 
-    {     
-        get_protocol().push(*this); 
-        return *this; 
-    }
+net::parameter_base& device_parameter::set_value(const ossia::value& val)
+{
+  if (val.valid())
+  {
+    m_current_value = val;
+    send(val);
+    device_update_value();
+  }
 
-    net::parameter_base& device_parameter::set_value(const ossia::value& val) 
-    {
-        if (val.valid()) {
-            m_current_value = val;
-            send(val);
-            device_update_value();
-        }
-        
-        return *this;
-    }
+  return *this;
+}
 
-    net::parameter_base& device_parameter::set_value(ossia::value&& val)
-    {
-        return set_value(val);
-    }
+net::parameter_base& device_parameter::set_value(ossia::value&& val)
+{
+  return set_value(val);
+}
 
-    val_type device_parameter::get_value_type() const 
-    {
-        return m_type;
-    }
+val_type device_parameter::get_value_type() const
+{
+  return m_type;
+}
 
-    access_mode device_parameter::get_access() const 
-    {   
-        return m_access;
-    }
+access_mode device_parameter::get_access() const
+{
+  return m_access;
+}
 
-    const domain& device_parameter::get_domain() const  
-    {
-        return m_domain; 
-    }
+const domain& device_parameter::get_domain() const
+{
+  return m_domain;
+}
 
-    bounding_mode device_parameter::get_bounding() const 
-    {   
-        return m_bounding;
-    }
-
+bounding_mode device_parameter::get_bounding() const
+{
+  return m_bounding;
 }
 }

--- a/OSSIA/ossia/network/joystick/device_parameter.hpp
+++ b/OSSIA/ossia/network/joystick/device_parameter.hpp
@@ -86,11 +86,11 @@ protected:
     return get_node().get_device().get_protocol();
   }
 
-  ossia::value m_current_value;
+  ossia::value m_current_value{};
 
-  const ossia::val_type m_type;
-  const ossia::bounding_mode m_bounding;
-  const ossia::access_mode m_access;
-  const ossia::domain m_domain;
+  const ossia::val_type m_type{};
+  const ossia::bounding_mode m_bounding{};
+  const ossia::access_mode m_access{};
+  const ossia::domain m_domain{};
 };
 }

--- a/OSSIA/ossia/network/joystick/device_parameter.hpp
+++ b/OSSIA/ossia/network/joystick/device_parameter.hpp
@@ -1,90 +1,96 @@
 
 #pragma once
 
-#include <ossia/network/value/value.hpp>
 #include <ossia/network/base/node.hpp>
 #include <ossia/network/base/protocol.hpp>
-#include <ossia/network/oscquery/oscquery_server.hpp>
 #include <ossia/network/common/complex_type.hpp>
 #include <ossia/network/domain/domain.hpp>
+#include <ossia/network/oscquery/oscquery_server.hpp>
+#include <ossia/network/value/value.hpp>
 
-namespace ossia
+namespace ossia::net
 {
-namespace net 
+
+class device_parameter : public ossia::net::parameter_base
 {
 
-    class device_parameter : public ossia::net::parameter_base
-    {
+public:
+  device_parameter(
+      ossia::net::node_base& node, const ossia::val_type type,
+      const ossia::bounding_mode bounding, const ossia::access_mode access,
+      const ossia::domain domain);
 
-        public:
-            device_parameter(
-                ossia::net::node_base& node,
-                const ossia::val_type type,
-                const ossia::bounding_mode bounding,
-                const ossia::access_mode access,
-                const ossia::domain domain);
+  virtual ~device_parameter();
 
-            virtual ~device_parameter();
+  void device_value_change_event(const ossia::value& value);
 
-            void device_value_change_event(const ossia::value& value);
+  void pull_value() override;
+  ossia::value value() const override;
 
-            void pull_value() override;
-            ossia::value value() const override;
-            
-            ossia::net::parameter_base& push_value(const ossia::value& val) override;
-            ossia::net::parameter_base& push_value(ossia::value&& val) override;
-            ossia::net::parameter_base& push_value() override;
+  ossia::net::parameter_base& push_value(const ossia::value& val) override;
+  ossia::net::parameter_base& push_value(ossia::value&& val) override;
+  ossia::net::parameter_base& push_value() override;
 
-            ossia::net::parameter_base& set_value(const ossia::value& val) override;
-            ossia::net::parameter_base& set_value(ossia::value&& v) override;
+  ossia::net::parameter_base& set_value(const ossia::value& val) override;
+  ossia::net::parameter_base& set_value(ossia::value&& v) override;
 
-            ossia::val_type get_value_type() const override;
-            ossia::net::parameter_base& set_value_type(ossia::val_type) override {return *this; }
+  ossia::val_type get_value_type() const override;
+  ossia::net::parameter_base& set_value_type(ossia::val_type) override
+  {
+    return *this;
+  }
 
-            ossia::access_mode get_access() const override;
-            ossia::net::parameter_base& set_access(ossia::access_mode) override { return *this; }
+  ossia::access_mode get_access() const override;
+  ossia::net::parameter_base& set_access(ossia::access_mode) override
+  {
+    return *this;
+  }
 
-            const ossia::domain& get_domain() const override;
-            ossia::net::parameter_base& set_domain(const ossia::domain&) override { return *this; }
+  const ossia::domain& get_domain() const override;
+  ossia::net::parameter_base& set_domain(const ossia::domain&) override
+  {
+    return *this;
+  }
 
-            ossia::bounding_mode get_bounding() const override;
-            ossia::net::parameter_base& set_bounding(ossia::bounding_mode) override { return *this; }
+  ossia::bounding_mode get_bounding() const override;
+  ossia::net::parameter_base& set_bounding(ossia::bounding_mode) override
+  {
+    return *this;
+  }
 
-            template<class ParamType = device_parameter, class ...T>
-            static ParamType *create_device_parameter(
-                ossia::net::node_base& root_node,
-                const std::string& path,
-                const ossia::value& initial_value,                
-                const T& ...ctor_args)
-            {
-                static_assert(std::is_base_of<device_parameter, ParamType>::value);
-                    
-                auto& param_node = 
-                    ossia::net::create_node(root_node, path);
-                auto param = 
-                    std::make_unique<ParamType>(param_node, ctor_args...);
+  template <class ParamType = device_parameter, class... T>
+  static ParamType* create_device_parameter(
+      ossia::net::node_base& root_node, const std::string& path,
+      const ossia::value& initial_value, const T&... ctor_args)
+  {
+    static_assert(std::is_base_of<device_parameter, ParamType>::value);
 
-                ParamType *ret = param.get();
+    auto& param_node = ossia::net::create_node(root_node, path);
+    auto param = std::make_unique<ParamType>(param_node, ctor_args...);
 
-                param->set_value(initial_value);
-                param_node.set_parameter(std::move(param));
+    ParamType* ret = param.get();
 
-                return ret;
-            }
+    param->set_value(initial_value);
+    param_node.set_parameter(std::move(param));
 
-        protected:
-            virtual void device_update_value() {}
+    return ret;
+  }
 
-            auto& get_protocol() { return get_node().get_device().get_protocol(); }
+protected:
+  virtual void device_update_value()
+  {
+  }
 
-            ossia::value m_current_value;
+  auto& get_protocol()
+  {
+    return get_node().get_device().get_protocol();
+  }
 
-            const ossia::val_type m_type;
-            const ossia::bounding_mode m_bounding;
-            const ossia::access_mode m_access;
-            const ossia::domain m_domain;
-    };
+  ossia::value m_current_value;
 
+  const ossia::val_type m_type;
+  const ossia::bounding_mode m_bounding;
+  const ossia::access_mode m_access;
+  const ossia::domain m_domain;
+};
 }
-}
-

--- a/OSSIA/ossia/network/joystick/device_parameter.hpp
+++ b/OSSIA/ossia/network/joystick/device_parameter.hpp
@@ -1,0 +1,90 @@
+
+#pragma once
+
+#include <ossia/network/value/value.hpp>
+#include <ossia/network/base/node.hpp>
+#include <ossia/network/base/protocol.hpp>
+#include <ossia/network/oscquery/oscquery_server.hpp>
+#include <ossia/network/common/complex_type.hpp>
+#include <ossia/network/domain/domain.hpp>
+
+namespace ossia
+{
+namespace net 
+{
+
+    class device_parameter : public ossia::net::parameter_base
+    {
+
+        public:
+            device_parameter(
+                ossia::net::node_base& node,
+                const ossia::val_type type,
+                const ossia::bounding_mode bounding,
+                const ossia::access_mode access,
+                const ossia::domain domain);
+
+            virtual ~device_parameter();
+
+            void device_value_change_event(const ossia::value& value);
+
+            void pull_value() override;
+            ossia::value value() const override;
+            
+            ossia::net::parameter_base& push_value(const ossia::value& val) override;
+            ossia::net::parameter_base& push_value(ossia::value&& val) override;
+            ossia::net::parameter_base& push_value() override;
+
+            ossia::net::parameter_base& set_value(const ossia::value& val) override;
+            ossia::net::parameter_base& set_value(ossia::value&& v) override;
+
+            ossia::val_type get_value_type() const override;
+            ossia::net::parameter_base& set_value_type(ossia::val_type) override {return *this; }
+
+            ossia::access_mode get_access() const override;
+            ossia::net::parameter_base& set_access(ossia::access_mode) override { return *this; }
+
+            const ossia::domain& get_domain() const override;
+            ossia::net::parameter_base& set_domain(const ossia::domain&) override { return *this; }
+
+            ossia::bounding_mode get_bounding() const override;
+            ossia::net::parameter_base& set_bounding(ossia::bounding_mode) override { return *this; }
+
+            template<class ParamType = device_parameter, class ...T>
+            static ParamType *create_device_parameter(
+                ossia::net::node_base& root_node,
+                const std::string& path,
+                const ossia::value& initial_value,                
+                const T& ...ctor_args)
+            {
+                static_assert(std::is_base_of<device_parameter, ParamType>::value);
+                    
+                auto& param_node = 
+                    ossia::net::create_node(root_node, path);
+                auto param = 
+                    std::make_unique<ParamType>(param_node, ctor_args...);
+
+                ParamType *ret = param.get();
+
+                param->set_value(initial_value);
+                param_node.set_parameter(std::move(param));
+
+                return ret;
+            }
+
+        protected:
+            virtual void device_update_value() {}
+
+            auto& get_protocol() { return get_node().get_device().get_protocol(); }
+
+            ossia::value m_current_value;
+
+            const ossia::val_type m_type;
+            const ossia::bounding_mode m_bounding;
+            const ossia::access_mode m_access;
+            const ossia::domain m_domain;
+    };
+
+}
+}
+

--- a/OSSIA/ossia/network/joystick/joystick_protocol.cpp
+++ b/OSSIA/ossia/network/joystick/joystick_protocol.cpp
@@ -60,6 +60,7 @@ joystick_protocol_manager::joystick_protocol_manager()
 
 joystick_protocol_manager::~joystick_protocol_manager()
 {
+  SDL_Quit();
   stop_event_loop();
 }
 
@@ -285,6 +286,11 @@ void joystick_protocol::set_device(ossia::net::device_base& dev)
   const int button_count = SDL_JoystickNumButtons(m_joystick);
 
   //  Build PArameters Tree
+
+  m_axis_parameters.reserve(axis_count);
+  m_button_parameters.reserve(button_count);
+  m_hat_parameters.reserve(hat_count);
+
   for (int i = 0; i < axis_count; ++i)
     m_axis_parameters.push_back(device_parameter::create_device_parameter(
         root, "axis-" + std::to_string(i + 1), 0.0, val_type::FLOAT,

--- a/OSSIA/ossia/network/joystick/joystick_protocol.cpp
+++ b/OSSIA/ossia/network/joystick/joystick_protocol.cpp
@@ -374,8 +374,6 @@ namespace ossia {
 
         int32_t joystick_protocol::get_joystick_id(const int index)
         {
-            if (index < 0)
-                throw std::runtime_error("Invalid Index");
             return SDL_JoystickGetDeviceInstanceID(index);
         }
 

--- a/OSSIA/ossia/network/joystick/joystick_protocol.cpp
+++ b/OSSIA/ossia/network/joystick/joystick_protocol.cpp
@@ -1,382 +1,364 @@
 
 
-#include <thread>
 #include <SDL2/SDL.h>
+#include <thread>
 
-#include "joystick_protocol.hpp"
 #include "device_parameter.hpp"
+#include "joystick_protocol.hpp"
 
+namespace ossia::net
+{
 
-namespace ossia {
+class joystick_protocol_manager
+{
 
-    namespace net {
+public:
+  static joystick_protocol_manager& get_instance();
 
-        class joystick_protocol_manager {
-            
-            public:
-                static joystick_protocol_manager& get_instance();
-            
-                bool joystick_is_registered(const SDL_JoystickID joystick_id);
-                void register_protocol(joystick_protocol& protocol);
-                void unregister_protocol(joystick_protocol& protoco);  
+  bool joystick_is_registered(const SDL_JoystickID joystick_id);
+  void register_protocol(joystick_protocol& protocol);
+  void unregister_protocol(joystick_protocol& protoco);
 
-                unsigned int get_joystick_count() const;
-                const char *get_joystick_name(const int joystick_index) const;
+  unsigned int get_joystick_count() const;
+  const char* get_joystick_name(const int joystick_index) const;
 
-                ~joystick_protocol_manager();
+  ~joystick_protocol_manager();
 
-            private:
-                joystick_protocol_manager();
+private:
+  joystick_protocol_manager();
 
-                void start_event_loop();
-                void stop_event_loop();
-
-                joystick_protocol *get_protocol_by_id(const SDL_JoystickID id);
-                static void event_loop();
-                
-                static std::unique_ptr<joystick_protocol_manager> m_instance;
-                std::map<SDL_JoystickID, joystick_protocol*> m_joystick_protocols;
-                std::mutex m_joystick_protocols_mutex;
-
-                bool m_event_loop_running{false};
-                std::thread m_event_loop_thread;
-        };
-
-        std::unique_ptr<joystick_protocol_manager> joystick_protocol_manager::m_instance{};
-
-        ////
-
-        joystick_protocol_manager::joystick_protocol_manager()
-        {
-            SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");  
-            //  Prevent SDL from setting SIGINT handler on Posix Systems
-            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
-
-            if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
-                throw std::runtime_error("SDL Init failure");
-
-            SDL_JoystickEventState(SDL_ENABLE);
-        }
+  void start_event_loop();
+  void stop_event_loop();
 
-        joystick_protocol_manager::~joystick_protocol_manager()
-        {
-            stop_event_loop();
-        }
-
-        void joystick_protocol_manager::start_event_loop()
-        {
-            if (m_event_loop_running)
-                return;
-            m_event_loop_running = true;
-            m_event_loop_thread = std::thread(event_loop);
-        }
+  joystick_protocol* get_protocol_by_id(const SDL_JoystickID id);
+  static void event_loop();
 
-        void joystick_protocol_manager::stop_event_loop()
-        {
-            if (!m_event_loop_running)
-                return;
+  static std::unique_ptr<joystick_protocol_manager> m_instance;
+  std::map<SDL_JoystickID, joystick_protocol*> m_joystick_protocols;
+  std::mutex m_joystick_protocols_mutex;
 
-            m_event_loop_running = false;
+  bool m_event_loop_running{false};
+  std::thread m_event_loop_thread;
+};
 
-            //  To be sure to quit the event loop
-            SDL_Event ev;
-            ev.type = SDL_FIRSTEVENT;
-            SDL_PushEvent(&ev);
+std::unique_ptr<joystick_protocol_manager>
+    joystick_protocol_manager::m_instance{};
 
-            if (m_event_loop_thread.joinable())
-                m_event_loop_thread.join();
-        }
-
-        joystick_protocol_manager& joystick_protocol_manager::get_instance()
-        {
-            if (!m_instance)
-                m_instance = std::unique_ptr<joystick_protocol_manager>(new joystick_protocol_manager);
-
-            return *m_instance;        
-        }
-
-        bool joystick_protocol_manager::joystick_is_registered(const SDL_JoystickID joystick_id)
-        {
-            return m_joystick_protocols.find(joystick_id) != m_joystick_protocols.end();
-        }
-
-        void joystick_protocol_manager::register_protocol(joystick_protocol& protocol)
-        {
-            const SDL_JoystickID joystick_id = protocol.m_joystick_id;
-
-            if (joystick_is_registered(joystick_id))
-                throw std::runtime_error("A protocol is already registered for this joystick");
-
-            m_joystick_protocols_mutex.lock();
-            m_joystick_protocols[joystick_id] = &protocol;
-            m_joystick_protocols_mutex.unlock();
-
-            //  If the manager event loop is not started, start it
-            if (!m_event_loop_running)
-                start_event_loop();
-        }
-
-        void joystick_protocol_manager::unregister_protocol(joystick_protocol& protocol)
-        {
-            const SDL_JoystickID  joystick_id = protocol.m_joystick_id;
-
-            if (!joystick_is_registered(joystick_id))
-                throw std::runtime_error("Cannot unregister a protocol that havent been registered");
-            
-            m_joystick_protocols_mutex.lock();
-            m_joystick_protocols.erase(joystick_id);
-            m_joystick_protocols_mutex.unlock();
-
-            //  If it was the last joystick, Stop The Event Loop
-            if (m_joystick_protocols.size() == 0)
-                stop_event_loop();
-        }
-
-        unsigned int joystick_protocol_manager::get_joystick_count() const
-        {
-            SDL_JoystickUpdate();
-            return static_cast<unsigned int>(SDL_NumJoysticks());
-        }
-
-        const char *joystick_protocol_manager::get_joystick_name(const int index) const
-        {
-            return SDL_JoystickNameForIndex(index);
-        }
-
-        joystick_protocol *joystick_protocol_manager::get_protocol_by_id(const SDL_JoystickID  id)
-        {
-            joystick_protocol *ret = nullptr;
-
-            m_joystick_protocols_mutex.lock();
-            auto it = m_joystick_protocols.find(id);
-
-            if (it != m_joystick_protocols.end())
-                ret = it->second;
-
-            m_joystick_protocols_mutex.unlock();
-
-            return ret;
-        }
-
-        void joystick_protocol_manager::event_loop()
-        {
-            if (!m_instance)
-                return;
-
-            auto& instance = *m_instance;            
-            SDL_Event ev;
-
-            while (instance.m_event_loop_running) {
-                SDL_WaitEvent(&ev);
-
-                switch (ev.type) {
-
-                    case SDL_JOYAXISMOTION:
-                        {
-                            const SDL_JoystickID joystick_id =
-                                ev.jaxis.which;
-
-                            joystick_protocol *protocol = 
-                                instance.get_protocol_by_id(joystick_id);
-
-                            if (protocol != nullptr)
-                                protocol->m_axis_parameters[ev.jaxis.axis]->
-                                    push_value(
-                                        static_cast<float>(ev.jaxis.value /
-                                        32767.0f));
-                        }
-                        break;
-
-                    case SDL_JOYBUTTONDOWN:
-                    case SDL_JOYBUTTONUP:
-                        {
-                            const SDL_JoystickID joystick_id =
-                                ev.jbutton.which;
-
-                            joystick_protocol *protocol = 
-                                instance.get_protocol_by_id(joystick_id);
-
-                            if (protocol != nullptr)
-                                protocol->m_button_parameters[ev.jbutton.button]->
-                                    push_value(ev.jbutton.state == SDL_PRESSED);                       
-                        }
-                        break;
-
-                    case SDL_JOYHATMOTION:
-                        {
-                            const SDL_JoystickID  joystick_id =
-                                ev.jhat.which;
-
-                            joystick_protocol *protocol = 
-                                instance.get_protocol_by_id(joystick_id);
-
-                            if (protocol != nullptr) {
-                                const uint8_t v = ev.jhat.value;
-                                float x = 0.0f, y = 0.0f;
-
-                                if (v & SDL_HAT_LEFT)
-                                    x = -1.0;
-                                else if (v & SDL_HAT_RIGHT)
-                                    x = 1.0;
-
-                                if (v & SDL_HAT_UP)
-                                    y = 1.0;
-                                else if (v & SDL_HAT_DOWN)
-                                    y = -1;
-
-                                protocol->m_hat_parameters[ev.jhat.hat]->
-                                    push_value(std::array<float, 2>{x, y});
-                            }
-                        }
-                        break;
-
-                    default:
-                        std::printf("Received unknown event of type %u (is not joy event)\n", ev.type);
-                        break;
-
-                }
-
-            }
-
-        }
-
-        /*
-         *
-         *      Joystick Protocol Implementation
-         *
-         */
-
-        joystick_protocol::joystick_protocol(
-                const int32_t joystick_id,
-                const int joystick_index)
-        :   m_joystick_id(joystick_id)
-        {
-
-            auto& mgr =
-                joystick_protocol_manager::get_instance();
-
-            //  Check That (ID, Index) is a valid combinaison
-            //  Could happen if a joystick is unpluged bettween settings and here
-            if (joystick_id != SDL_JoystickGetDeviceInstanceID(joystick_index))
-                throw std::runtime_error("Invalid Settings");
-
-            //  Check that this ID is not already registered
-            if (mgr.joystick_is_registered(m_joystick_id))
-                throw std::runtime_error("This Joystick is already open");
-
-            //  Open The Joystick
-            m_joystick = SDL_JoystickOpen(joystick_index);
-
-            if (m_joystick == nullptr)
-                throw std::runtime_error("Failed to open Joystick");
-
-        }
-
-        joystick_protocol::~joystick_protocol()
-        {
-            stop();
-        }
-
-        void joystick_protocol::set_device(ossia::net::device_base& dev)
-        {        
-            m_device = &dev;
-            auto& root = dev.get_root_node();
-
-            //  Retrive Joystick Info
-            const int axis_count = SDL_JoystickNumAxes(m_joystick);
-            //const int ball_count = SDL_JoystickNumBalls(m_joystick);
-            const int hat_count = SDL_JoystickNumHats(m_joystick);
-            const int button_count = SDL_JoystickNumButtons(m_joystick);
-
-            //  Build PArameters Tree
-            for (int i = 0; i < axis_count; ++i)
-                m_axis_parameters.push_back(
-                    device_parameter::create_device_parameter(
-                        root, "axis-" + std::to_string(i + 1),
-                        0.0, val_type::FLOAT, 
-                        bounding_mode::CLIP, access_mode::GET, 
-                        make_domain(-1.0f, 1.0f)));
-    
-            for (int i = 0; i < button_count; ++i)
-                m_button_parameters.push_back(
-                    device_parameter::create_device_parameter(
-                        root, "button-" + std::to_string(i + 1),
-                        false, val_type::BOOL, 
-                        bounding_mode::CLIP, access_mode::GET,
-                        init_domain(val_type::BOOL)));
-            
-            for (int i = 0; i < hat_count; ++i)
-                m_hat_parameters.push_back(
-                    device_parameter::create_device_parameter(
-                        root, "hat-" + std::to_string(i + 1),
-                        std::array<float, 2>{0.0, 0.0}, val_type::VEC2F,
-                        bounding_mode::FREE, access_mode::GET,
-                        init_domain(val_type::VEC2F)));
-
-            //  Register The Protocol
-            auto& mgr =
-                joystick_protocol_manager::get_instance();
-            mgr.register_protocol(*this);
-        }
-
-        bool joystick_protocol::pull(net::parameter_base& param)
-        {
-            return true;
-        }
-
-        bool joystick_protocol::push(const net::parameter_base& param)
-        {
-            return true;
-        }
-
-        bool joystick_protocol::observe(net::parameter_base& param, bool enable)
-        {
-            return false;
-        }
-
-        bool joystick_protocol::push_raw(const ossia::net::full_parameter_data& data)
-        {
-            return false;
-        }
-
-        bool joystick_protocol::update(ossia::net::node_base&)
-        {
-            return true;
-        }
-
-        void joystick_protocol::stop()
-        {
-            if (m_joystick != nullptr) {
-                auto& mgr =
-                    joystick_protocol_manager::get_instance();
-
-                mgr.unregister_protocol(*this);
-                SDL_JoystickClose(m_joystick);
-                m_joystick = nullptr;
-            }
-        }
-
-        unsigned int joystick_protocol::get_joystick_count()
-        {
-            auto& mgr =
-                joystick_protocol_manager::get_instance();
-
-            return mgr.get_joystick_count();
-        }
-
-        const char *joystick_protocol::get_joystick_name(const int index)
-        {
-            auto& mgr =
-                joystick_protocol_manager::get_instance();
-
-            return mgr.get_joystick_name(index);
-        }
-
-        int32_t joystick_protocol::get_joystick_id(const int index)
-        {
-            return SDL_JoystickGetDeviceInstanceID(index);
-        }
-
-    }
+////
+
+joystick_protocol_manager::joystick_protocol_manager()
+{
+  SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");
+  //  Prevent SDL from setting SIGINT handler on Posix Systems
+  SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+
+  if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
+    throw std::runtime_error("SDL Init failure");
+
+  SDL_JoystickEventState(SDL_ENABLE);
 }
 
+joystick_protocol_manager::~joystick_protocol_manager()
+{
+  stop_event_loop();
+}
+
+void joystick_protocol_manager::start_event_loop()
+{
+  if (m_event_loop_running)
+    return;
+  m_event_loop_running = true;
+  m_event_loop_thread = std::thread(event_loop);
+}
+
+void joystick_protocol_manager::stop_event_loop()
+{
+  if (!m_event_loop_running)
+    return;
+
+  m_event_loop_running = false;
+
+  //  To be sure to quit the event loop
+  SDL_Event ev;
+  ev.type = SDL_FIRSTEVENT;
+  SDL_PushEvent(&ev);
+
+  if (m_event_loop_thread.joinable())
+    m_event_loop_thread.join();
+}
+
+joystick_protocol_manager& joystick_protocol_manager::get_instance()
+{
+  if (!m_instance)
+    m_instance = std::unique_ptr<joystick_protocol_manager>(
+        new joystick_protocol_manager);
+
+  return *m_instance;
+}
+
+bool joystick_protocol_manager::joystick_is_registered(
+    const SDL_JoystickID joystick_id)
+{
+  return m_joystick_protocols.find(joystick_id) != m_joystick_protocols.end();
+}
+
+void joystick_protocol_manager::register_protocol(joystick_protocol& protocol)
+{
+  const SDL_JoystickID joystick_id = protocol.m_joystick_id;
+
+  if (joystick_is_registered(joystick_id))
+    throw std::runtime_error(
+        "A protocol is already registered for this joystick");
+
+  m_joystick_protocols_mutex.lock();
+  m_joystick_protocols[joystick_id] = &protocol;
+  m_joystick_protocols_mutex.unlock();
+
+  //  If the manager event loop is not started, start it
+  if (!m_event_loop_running)
+    start_event_loop();
+}
+
+void joystick_protocol_manager::unregister_protocol(
+    joystick_protocol& protocol)
+{
+  const SDL_JoystickID joystick_id = protocol.m_joystick_id;
+
+  if (!joystick_is_registered(joystick_id))
+    throw std::runtime_error(
+        "Cannot unregister a protocol that havent been registered");
+
+  m_joystick_protocols_mutex.lock();
+  m_joystick_protocols.erase(joystick_id);
+  m_joystick_protocols_mutex.unlock();
+
+  //  If it was the last joystick, Stop The Event Loop
+  if (m_joystick_protocols.size() == 0)
+    stop_event_loop();
+}
+
+unsigned int joystick_protocol_manager::get_joystick_count() const
+{
+  SDL_JoystickUpdate();
+  return static_cast<unsigned int>(SDL_NumJoysticks());
+}
+
+const char* joystick_protocol_manager::get_joystick_name(const int index) const
+{
+  return SDL_JoystickNameForIndex(index);
+}
+
+joystick_protocol*
+joystick_protocol_manager::get_protocol_by_id(const SDL_JoystickID id)
+{
+  joystick_protocol* ret = nullptr;
+
+  m_joystick_protocols_mutex.lock();
+  auto it = m_joystick_protocols.find(id);
+
+  if (it != m_joystick_protocols.end())
+    ret = it->second;
+
+  m_joystick_protocols_mutex.unlock();
+
+  return ret;
+}
+
+void joystick_protocol_manager::event_loop()
+{
+  if (!m_instance)
+    return;
+
+  auto& instance = *m_instance;
+  SDL_Event ev;
+
+  while (instance.m_event_loop_running)
+  {
+    SDL_WaitEvent(&ev);
+
+    switch (ev.type)
+    {
+
+      case SDL_JOYAXISMOTION:
+      {
+        const SDL_JoystickID joystick_id = ev.jaxis.which;
+
+        joystick_protocol* protocol = instance.get_protocol_by_id(joystick_id);
+
+        if (protocol != nullptr)
+          protocol->m_axis_parameters[ev.jaxis.axis]->push_value(
+              static_cast<float>(ev.jaxis.value / 32767.0f));
+      }
+      break;
+
+      case SDL_JOYBUTTONDOWN:
+      case SDL_JOYBUTTONUP:
+      {
+        const SDL_JoystickID joystick_id = ev.jbutton.which;
+
+        joystick_protocol* protocol = instance.get_protocol_by_id(joystick_id);
+
+        if (protocol != nullptr)
+          protocol->m_button_parameters[ev.jbutton.button]->push_value(
+              ev.jbutton.state == SDL_PRESSED);
+      }
+      break;
+
+      case SDL_JOYHATMOTION:
+      {
+        const SDL_JoystickID joystick_id = ev.jhat.which;
+
+        joystick_protocol* protocol = instance.get_protocol_by_id(joystick_id);
+
+        if (protocol != nullptr)
+        {
+          const uint8_t v = ev.jhat.value;
+          float x = 0.0f, y = 0.0f;
+
+          if (v & SDL_HAT_LEFT)
+            x = -1.0;
+          else if (v & SDL_HAT_RIGHT)
+            x = 1.0;
+
+          if (v & SDL_HAT_UP)
+            y = 1.0;
+          else if (v & SDL_HAT_DOWN)
+            y = -1;
+
+          protocol->m_hat_parameters[ev.jhat.hat]->push_value(
+              std::array<float, 2>{x, y});
+        }
+      }
+      break;
+
+      default:
+        std::printf(
+            "Received unknown event of type %u (is not joy event)\n", ev.type);
+        break;
+    }
+  }
+}
+
+/*
+ *
+ *      Joystick Protocol Implementation
+ *
+ */
+
+joystick_protocol::joystick_protocol(
+    const int32_t joystick_id, const int joystick_index)
+    : m_joystick_id(joystick_id)
+{
+
+  auto& mgr = joystick_protocol_manager::get_instance();
+
+  //  Check That (ID, Index) is a valid combinaison
+  //  Could happen if a joystick is unpluged bettween settings and here
+  if (joystick_id != SDL_JoystickGetDeviceInstanceID(joystick_index))
+    throw std::runtime_error("Invalid Settings");
+
+  //  Check that this ID is not already registered
+  if (mgr.joystick_is_registered(m_joystick_id))
+    throw std::runtime_error("This Joystick is already open");
+
+  //  Open The Joystick
+  m_joystick = SDL_JoystickOpen(joystick_index);
+
+  if (m_joystick == nullptr)
+    throw std::runtime_error("Failed to open Joystick");
+}
+
+joystick_protocol::~joystick_protocol()
+{
+  stop();
+}
+
+void joystick_protocol::set_device(ossia::net::device_base& dev)
+{
+  m_device = &dev;
+  auto& root = dev.get_root_node();
+
+  //  Retrive Joystick Info
+  const int axis_count = SDL_JoystickNumAxes(m_joystick);
+  // const int ball_count = SDL_JoystickNumBalls(m_joystick);
+  const int hat_count = SDL_JoystickNumHats(m_joystick);
+  const int button_count = SDL_JoystickNumButtons(m_joystick);
+
+  //  Build PArameters Tree
+  for (int i = 0; i < axis_count; ++i)
+    m_axis_parameters.push_back(device_parameter::create_device_parameter(
+        root, "axis-" + std::to_string(i + 1), 0.0, val_type::FLOAT,
+        bounding_mode::CLIP, access_mode::GET, make_domain(-1.0f, 1.0f)));
+
+  for (int i = 0; i < button_count; ++i)
+    m_button_parameters.push_back(device_parameter::create_device_parameter(
+        root, "button-" + std::to_string(i + 1), false, val_type::BOOL,
+        bounding_mode::CLIP, access_mode::GET, init_domain(val_type::BOOL)));
+
+  for (int i = 0; i < hat_count; ++i)
+    m_hat_parameters.push_back(device_parameter::create_device_parameter(
+        root, "hat-" + std::to_string(i + 1), std::array<float, 2>{0.0, 0.0},
+        val_type::VEC2F, bounding_mode::FREE, access_mode::GET,
+        init_domain(val_type::VEC2F)));
+
+  //  Register The Protocol
+  auto& mgr = joystick_protocol_manager::get_instance();
+  mgr.register_protocol(*this);
+}
+
+bool joystick_protocol::pull(net::parameter_base& param)
+{
+  return true;
+}
+
+bool joystick_protocol::push(const net::parameter_base& param)
+{
+  return true;
+}
+
+bool joystick_protocol::observe(net::parameter_base& param, bool enable)
+{
+  return false;
+}
+
+bool joystick_protocol::push_raw(const ossia::net::full_parameter_data& data)
+{
+  return false;
+}
+
+bool joystick_protocol::update(ossia::net::node_base&)
+{
+  return true;
+}
+
+void joystick_protocol::stop()
+{
+  if (m_joystick != nullptr)
+  {
+    auto& mgr = joystick_protocol_manager::get_instance();
+
+    mgr.unregister_protocol(*this);
+    SDL_JoystickClose(m_joystick);
+    m_joystick = nullptr;
+  }
+}
+
+unsigned int joystick_protocol::get_joystick_count()
+{
+  auto& mgr = joystick_protocol_manager::get_instance();
+
+  return mgr.get_joystick_count();
+}
+
+const char* joystick_protocol::get_joystick_name(const int index)
+{
+  auto& mgr = joystick_protocol_manager::get_instance();
+
+  return mgr.get_joystick_name(index);
+}
+
+int32_t joystick_protocol::get_joystick_id(const int index)
+{
+  return SDL_JoystickGetDeviceInstanceID(index);
+}
+}

--- a/OSSIA/ossia/network/joystick/joystick_protocol.cpp
+++ b/OSSIA/ossia/network/joystick/joystick_protocol.cpp
@@ -1,0 +1,384 @@
+
+
+#include <thread>
+#include <SDL2/SDL.h>
+
+#include "joystick_protocol.hpp"
+#include "device_parameter.hpp"
+
+
+namespace ossia {
+
+    namespace net {
+
+        class joystick_protocol_manager {
+            
+            public:
+                static joystick_protocol_manager& get_instance();
+            
+                bool joystick_is_registered(const SDL_JoystickID joystick_id);
+                void register_protocol(joystick_protocol& protocol);
+                void unregister_protocol(joystick_protocol& protoco);  
+
+                unsigned int get_joystick_count() const;
+                const char *get_joystick_name(const int joystick_index) const;
+
+                ~joystick_protocol_manager();
+
+            private:
+                joystick_protocol_manager();
+
+                void start_event_loop();
+                void stop_event_loop();
+
+                joystick_protocol *get_protocol_by_id(const SDL_JoystickID id);
+                static void event_loop();
+                
+                static std::unique_ptr<joystick_protocol_manager> m_instance;
+                std::map<SDL_JoystickID, joystick_protocol*> m_joystick_protocols;
+                std::mutex m_joystick_protocols_mutex;
+
+                bool m_event_loop_running{false};
+                std::thread m_event_loop_thread;
+        };
+
+        std::unique_ptr<joystick_protocol_manager> joystick_protocol_manager::m_instance{};
+
+        ////
+
+        joystick_protocol_manager::joystick_protocol_manager()
+        {
+            SDL_SetHint(SDL_HINT_NO_SIGNAL_HANDLERS, "1");  
+            //  Prevent SDL from setting SIGINT handler on Posix Systems
+            SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
+
+            if (SDL_Init(SDL_INIT_JOYSTICK) < 0)
+                throw std::runtime_error("SDL Init failure");
+
+            SDL_JoystickEventState(SDL_ENABLE);
+        }
+
+        joystick_protocol_manager::~joystick_protocol_manager()
+        {
+            stop_event_loop();
+        }
+
+        void joystick_protocol_manager::start_event_loop()
+        {
+            if (m_event_loop_running)
+                return;
+            m_event_loop_running = true;
+            m_event_loop_thread = std::thread(event_loop);
+        }
+
+        void joystick_protocol_manager::stop_event_loop()
+        {
+            if (!m_event_loop_running)
+                return;
+
+            m_event_loop_running = false;
+
+            //  To be sure to quit the event loop
+            SDL_Event ev;
+            ev.type = SDL_FIRSTEVENT;
+            SDL_PushEvent(&ev);
+
+            if (m_event_loop_thread.joinable())
+                m_event_loop_thread.join();
+        }
+
+        joystick_protocol_manager& joystick_protocol_manager::get_instance()
+        {
+            if (!m_instance)
+                m_instance = std::unique_ptr<joystick_protocol_manager>(new joystick_protocol_manager);
+
+            return *m_instance;        
+        }
+
+        bool joystick_protocol_manager::joystick_is_registered(const SDL_JoystickID joystick_id)
+        {
+            return m_joystick_protocols.find(joystick_id) != m_joystick_protocols.end();
+        }
+
+        void joystick_protocol_manager::register_protocol(joystick_protocol& protocol)
+        {
+            const SDL_JoystickID joystick_id = protocol.m_joystick_id;
+
+            if (joystick_is_registered(joystick_id))
+                throw std::runtime_error("A protocol is already registered for this joystick");
+
+            m_joystick_protocols_mutex.lock();
+            m_joystick_protocols[joystick_id] = &protocol;
+            m_joystick_protocols_mutex.unlock();
+
+            //  If the manager event loop is not started, start it
+            if (!m_event_loop_running)
+                start_event_loop();
+        }
+
+        void joystick_protocol_manager::unregister_protocol(joystick_protocol& protocol)
+        {
+            const SDL_JoystickID  joystick_id = protocol.m_joystick_id;
+
+            if (!joystick_is_registered(joystick_id))
+                throw std::runtime_error("Cannot unregister a protocol that havent been registered");
+            
+            m_joystick_protocols_mutex.lock();
+            m_joystick_protocols.erase(joystick_id);
+            m_joystick_protocols_mutex.unlock();
+
+            //  If it was the last joystick, Stop The Event Loop
+            if (m_joystick_protocols.size() == 0)
+                stop_event_loop();
+        }
+
+        unsigned int joystick_protocol_manager::get_joystick_count() const
+        {
+            SDL_JoystickUpdate();
+            return static_cast<unsigned int>(SDL_NumJoysticks());
+        }
+
+        const char *joystick_protocol_manager::get_joystick_name(const int index) const
+        {
+            return SDL_JoystickNameForIndex(index);
+        }
+
+        joystick_protocol *joystick_protocol_manager::get_protocol_by_id(const SDL_JoystickID  id)
+        {
+            joystick_protocol *ret = nullptr;
+
+            m_joystick_protocols_mutex.lock();
+            auto it = m_joystick_protocols.find(id);
+
+            if (it != m_joystick_protocols.end())
+                ret = it->second;
+
+            m_joystick_protocols_mutex.unlock();
+
+            return ret;
+        }
+
+        void joystick_protocol_manager::event_loop()
+        {
+            if (!m_instance)
+                return;
+
+            auto& instance = *m_instance;            
+            SDL_Event ev;
+
+            while (instance.m_event_loop_running) {
+                SDL_WaitEvent(&ev);
+
+                switch (ev.type) {
+
+                    case SDL_JOYAXISMOTION:
+                        {
+                            const SDL_JoystickID joystick_id =
+                                ev.jaxis.which;
+
+                            joystick_protocol *protocol = 
+                                instance.get_protocol_by_id(joystick_id);
+
+                            if (protocol != nullptr)
+                                protocol->m_axis_parameters[ev.jaxis.axis]->
+                                    push_value(
+                                        static_cast<float>(ev.jaxis.value /
+                                        32767.0f));
+                        }
+                        break;
+
+                    case SDL_JOYBUTTONDOWN:
+                    case SDL_JOYBUTTONUP:
+                        {
+                            const SDL_JoystickID joystick_id =
+                                ev.jbutton.which;
+
+                            joystick_protocol *protocol = 
+                                instance.get_protocol_by_id(joystick_id);
+
+                            if (protocol != nullptr)
+                                protocol->m_button_parameters[ev.jbutton.button]->
+                                    push_value(ev.jbutton.state == SDL_PRESSED);                       
+                        }
+                        break;
+
+                    case SDL_JOYHATMOTION:
+                        {
+                            const SDL_JoystickID  joystick_id =
+                                ev.jhat.which;
+
+                            joystick_protocol *protocol = 
+                                instance.get_protocol_by_id(joystick_id);
+
+                            if (protocol != nullptr) {
+                                const uint8_t v = ev.jhat.value;
+                                float x = 0.0f, y = 0.0f;
+
+                                if (v & SDL_HAT_LEFT)
+                                    x = -1.0;
+                                else if (v & SDL_HAT_RIGHT)
+                                    x = 1.0;
+
+                                if (v & SDL_HAT_UP)
+                                    y = 1.0;
+                                else if (v & SDL_HAT_DOWN)
+                                    y = -1;
+
+                                protocol->m_hat_parameters[ev.jhat.hat]->
+                                    push_value(std::array<float, 2>{x, y});
+                            }
+                        }
+                        break;
+
+                    default:
+                        std::printf("Received unknown event of type %u (is not joy event)\n", ev.type);
+                        break;
+
+                }
+
+            }
+
+        }
+
+        /*
+         *
+         *      Joystick Protocol Implementation
+         *
+         */
+
+        joystick_protocol::joystick_protocol(
+                const int32_t joystick_id,
+                const int joystick_index)
+        :   m_joystick_id(joystick_id)
+        {
+
+            auto& mgr =
+                joystick_protocol_manager::get_instance();
+
+            //  Check That (ID, Index) is a valid combinaison
+            //  Could happen if a joystick is unpluged bettween settings and here
+            if (joystick_id != SDL_JoystickGetDeviceInstanceID(joystick_index))
+                throw std::runtime_error("Invalid Settings");
+
+            //  Check that this ID is not already registered
+            if (mgr.joystick_is_registered(m_joystick_id))
+                throw std::runtime_error("This Joystick is already open");
+
+            //  Open The Joystick
+            m_joystick = SDL_JoystickOpen(joystick_index);
+
+            if (m_joystick == nullptr)
+                throw std::runtime_error("Failed to open Joystick");
+
+        }
+
+        joystick_protocol::~joystick_protocol()
+        {
+            stop();
+        }
+
+        void joystick_protocol::set_device(ossia::net::device_base& dev)
+        {        
+            m_device = &dev;
+            auto& root = dev.get_root_node();
+
+            //  Retrive Joystick Info
+            const int axis_count = SDL_JoystickNumAxes(m_joystick);
+            //const int ball_count = SDL_JoystickNumBalls(m_joystick);
+            const int hat_count = SDL_JoystickNumHats(m_joystick);
+            const int button_count = SDL_JoystickNumButtons(m_joystick);
+
+            //  Build PArameters Tree
+            for (int i = 0; i < axis_count; ++i)
+                m_axis_parameters.push_back(
+                    device_parameter::create_device_parameter(
+                        root, "axis-" + std::to_string(i + 1),
+                        0.0, val_type::FLOAT, 
+                        bounding_mode::CLIP, access_mode::GET, 
+                        make_domain(-1.0f, 1.0f)));
+    
+            for (int i = 0; i < button_count; ++i)
+                m_button_parameters.push_back(
+                    device_parameter::create_device_parameter(
+                        root, "button-" + std::to_string(i + 1),
+                        false, val_type::BOOL, 
+                        bounding_mode::CLIP, access_mode::GET,
+                        init_domain(val_type::BOOL)));
+            
+            for (int i = 0; i < hat_count; ++i)
+                m_hat_parameters.push_back(
+                    device_parameter::create_device_parameter(
+                        root, "hat-" + std::to_string(i + 1),
+                        std::array<float, 2>{0.0, 0.0}, val_type::VEC2F,
+                        bounding_mode::FREE, access_mode::GET,
+                        init_domain(val_type::VEC2F)));
+
+            //  Register The Protocol
+            auto& mgr =
+                joystick_protocol_manager::get_instance();
+            mgr.register_protocol(*this);
+        }
+
+        bool joystick_protocol::pull(net::parameter_base& param)
+        {
+            return true;
+        }
+
+        bool joystick_protocol::push(const net::parameter_base& param)
+        {
+            return true;
+        }
+
+        bool joystick_protocol::observe(net::parameter_base& param, bool enable)
+        {
+            return false;
+        }
+
+        bool joystick_protocol::push_raw(const ossia::net::full_parameter_data& data)
+        {
+            return false;
+        }
+
+        bool joystick_protocol::update(ossia::net::node_base&)
+        {
+            return true;
+        }
+
+        void joystick_protocol::stop()
+        {
+            if (m_joystick != nullptr) {
+                auto& mgr =
+                    joystick_protocol_manager::get_instance();
+
+                mgr.unregister_protocol(*this);
+                SDL_JoystickClose(m_joystick);
+                m_joystick = nullptr;
+            }
+        }
+
+        unsigned int joystick_protocol::get_joystick_count()
+        {
+            auto& mgr =
+                joystick_protocol_manager::get_instance();
+
+            return mgr.get_joystick_count();
+        }
+
+        const char *joystick_protocol::get_joystick_name(const int index)
+        {
+            auto& mgr =
+                joystick_protocol_manager::get_instance();
+
+            return mgr.get_joystick_name(index);
+        }
+
+        int32_t joystick_protocol::get_joystick_id(const int index)
+        {
+            if (index < 0)
+                throw std::runtime_error("Invalid Index");
+            return SDL_JoystickGetDeviceInstanceID(index);
+        }
+
+    }
+}
+

--- a/OSSIA/ossia/network/joystick/joystick_protocol.hpp
+++ b/OSSIA/ossia/network/joystick/joystick_protocol.hpp
@@ -1,0 +1,62 @@
+
+#pragma once
+
+#include <vector>
+
+#include <ossia/network/base/protocol.hpp>
+#include <ossia/network/oscquery/oscquery_server.hpp>
+#include <ossia/network/common/complex_type.hpp>
+#include <ossia/network/domain/domain.hpp>
+
+#include "device_parameter.hpp"
+
+typedef struct _SDL_Joystick SDL_Joystick;
+
+namespace ossia
+{
+namespace net {
+
+    class OSSIA_EXPORT joystick_protocol final :
+        public ossia::net::protocol_base
+    {
+        friend class joystick_protocol_manager;
+        
+        public:
+            joystick_protocol(
+                const int32_t joystick_id,
+                const int joystick_index);
+            joystick_protocol(joystick_protocol&) = delete;
+            ~joystick_protocol();
+
+            void set_device(ossia::net::device_base& dev) override;
+
+            bool pull(ossia::net::parameter_base& param) override;
+            bool push(const ossia::net::parameter_base& param) override;
+            bool push_raw(const ossia::net::full_parameter_data&) override;
+            bool observe(ossia::net::parameter_base& param, bool enable) override;
+    
+            bool update(ossia::net::node_base&) override;
+            void stop() override;
+
+            static unsigned int get_joystick_count();
+            static const char *get_joystick_name(const int index);
+            static int32_t get_joystick_id(const int index);
+
+        private:
+            ossia::net::device_base* m_device{};
+            
+            std::vector<device_parameter*> m_axis_parameters;
+            std::vector<device_parameter*> m_hat_parameters;
+            std::vector<device_parameter*> m_ball_parameters;
+            std::vector<device_parameter*> m_button_parameters;
+
+            int32_t m_joystick_id;
+            SDL_Joystick *m_joystick{};
+    };
+
+    
+
+
+
+}
+}

--- a/OSSIA/ossia/network/joystick/joystick_protocol.hpp
+++ b/OSSIA/ossia/network/joystick/joystick_protocol.hpp
@@ -4,59 +4,49 @@
 #include <vector>
 
 #include <ossia/network/base/protocol.hpp>
-#include <ossia/network/oscquery/oscquery_server.hpp>
 #include <ossia/network/common/complex_type.hpp>
 #include <ossia/network/domain/domain.hpp>
+#include <ossia/network/oscquery/oscquery_server.hpp>
 
 #include "device_parameter.hpp"
 
 typedef struct _SDL_Joystick SDL_Joystick;
 
-namespace ossia
+namespace ossia::net
 {
-namespace net {
 
-    class OSSIA_EXPORT joystick_protocol final :
-        public ossia::net::protocol_base
-    {
-        friend class joystick_protocol_manager;
-        
-        public:
-            joystick_protocol(
-                const int32_t joystick_id,
-                const int joystick_index);
-            joystick_protocol(joystick_protocol&) = delete;
-            ~joystick_protocol();
+class OSSIA_EXPORT joystick_protocol final : public ossia::net::protocol_base
+{
+  friend class joystick_protocol_manager;
 
-            void set_device(ossia::net::device_base& dev) override;
+public:
+  joystick_protocol(const int32_t joystick_id, const int joystick_index);
+  joystick_protocol(joystick_protocol&) = delete;
+  ~joystick_protocol();
 
-            bool pull(ossia::net::parameter_base& param) override;
-            bool push(const ossia::net::parameter_base& param) override;
-            bool push_raw(const ossia::net::full_parameter_data&) override;
-            bool observe(ossia::net::parameter_base& param, bool enable) override;
-    
-            bool update(ossia::net::node_base&) override;
-            void stop() override;
+  void set_device(ossia::net::device_base& dev) override;
 
-            static unsigned int get_joystick_count();
-            static const char *get_joystick_name(const int index);
-            static int32_t get_joystick_id(const int index);
+  bool pull(ossia::net::parameter_base& param) override;
+  bool push(const ossia::net::parameter_base& param) override;
+  bool push_raw(const ossia::net::full_parameter_data&) override;
+  bool observe(ossia::net::parameter_base& param, bool enable) override;
 
-        private:
-            ossia::net::device_base* m_device{};
-            
-            std::vector<device_parameter*> m_axis_parameters;
-            std::vector<device_parameter*> m_hat_parameters;
-            std::vector<device_parameter*> m_ball_parameters;
-            std::vector<device_parameter*> m_button_parameters;
+  bool update(ossia::net::node_base&) override;
+  void stop() override;
 
-            int32_t m_joystick_id;
-            SDL_Joystick *m_joystick{};
-    };
+  static unsigned int get_joystick_count();
+  static const char* get_joystick_name(const int index);
+  static int32_t get_joystick_id(const int index);
 
-    
+private:
+  ossia::net::device_base* m_device{};
 
+  std::vector<device_parameter*> m_axis_parameters;
+  std::vector<device_parameter*> m_hat_parameters;
+  std::vector<device_parameter*> m_ball_parameters;
+  std::vector<device_parameter*> m_button_parameters;
 
-
-}
+  int32_t m_joystick_id;
+  SDL_Joystick* m_joystick{};
+};
 }

--- a/OSSIA/ossia/network/joystick/joystick_protocol.hpp
+++ b/OSSIA/ossia/network/joystick/joystick_protocol.hpp
@@ -21,7 +21,10 @@ class OSSIA_EXPORT joystick_protocol final : public ossia::net::protocol_base
 
 public:
   joystick_protocol(const int32_t joystick_id, const int joystick_index);
-  joystick_protocol(joystick_protocol&) = delete;
+  joystick_protocol(const joystick_protocol&) = delete;
+  joystick_protocol(joystick_protocol&&) = delete;
+  joystick_protocol& operator=(const joystick_protocol&) = delete;
+  joystick_protocol& operator=(joystick_protocol&&) = delete;
   ~joystick_protocol();
 
   void set_device(ossia::net::device_base& dev) override;

--- a/OSSIA/ossia_sources.cmake
+++ b/OSSIA/ossia_sources.cmake
@@ -379,7 +379,6 @@ set(OSSIA_SERIAL_SRCS
     "${CMAKE_CURRENT_SOURCE_DIR}/ossia-qt/serial/serial_parameter.cpp"
 )
 
-
 set(OSSIA_PHIDGETS_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/ossia/network/phidgets/detail/sensors.hpp"
 
@@ -397,6 +396,14 @@ set(OSSIA_LEAPMOTION_HEADERS
 
 set(OSSIA_LEAPMOTION_SRCS
   "${CMAKE_CURRENT_SOURCE_DIR}/ossia/network/leapmotion/leapmotion_device.cpp")
+
+set(OSSIA_JOYSTICK_HEADERS
+  "${CMAKE_CURRENT_SOURCE_DIR}/ossia/network/joystick/device_parameter.hpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/ossia/network/joystick/joystick_protocol.hpp")
+
+set(OSSIA_JOYSTICK_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/ossia/network/joystick/device_parameter.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/ossia/network/joystick/joystick_protocol.cpp")
 
 set(OSSIA_WS_CLIENT_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/ossia-qt/websocket-generic-client/ws_generic_client_device.hpp"


### PR DESCRIPTION

I have done a fix in generic device : change_tree capabilities is set BEFORE calling protocol::set_device

SDL2 backbend is used. SDL2 must be initialized only once and thus if some other part of the project want to use SDL2 too, it will be necessary to mutualize the SDL2 initialization. 

The trackballs are not yet supported because I a haven't one to do test but it would be a 10 minute task to add this. see [https://github.com/aliefhooghe/libossia/blob/master/OSSIA/ossia/network/joystick/joystick_protocol.cpp#L287](url)

