### PR TITLE
ossia.list2parameter back to Jamoma style

### DIFF
--- a/OSSIA/ossia-max/patchers/ossia.list2parameter/ossia.list2parameter.maxhelp
+++ b/OSSIA/ossia-max/patchers/ossia.list2parameter/ossia.list2parameter.maxhelp
@@ -2,14 +2,13 @@
 	"patcher" : 	{
 		"fileversion" : 1,
 		"appversion" : 		{
-			"major" : 8,
-			"minor" : 0,
-			"revision" : 6,
-			"architecture" : "x64",
+			"major" : 7,
+			"minor" : 3,
+			"revision" : 5,
+			"architecture" : "x86",
 			"modernui" : 1
 		}
 ,
-		"classnamespace" : "box",
 		"rect" : [ 100.0, 100.0, 699.0, 368.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
@@ -60,6 +59,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 7.0, 68.0, 542.0, 20.0 ],
+					"style" : "",
 					"text" : "Make life easier when accessing the individual members of a @type list parameter in the GUI"
 				}
 
@@ -75,7 +75,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 260.0, 308.0, 165.0, 22.0 ],
-					"text" : "10 20 30"
+					"style" : ""
 				}
 
 			}
@@ -90,6 +90,7 @@
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
 					"patching_rect" : [ 258.0, 274.0, 191.0, 22.0 ],
+					"style" : "",
 					"text" : "ossia.parameter testing @type list",
 					"varname" : "testing[1]"
 				}
@@ -104,7 +105,8 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 501.0, 124.0, 105.0, 22.0 ],
+					"patching_rect" : [ 502.0, 124.0, 105.0, 22.0 ],
+					"style" : "",
 					"text" : "11.11 22.22 33.33"
 				}
 
@@ -119,6 +121,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 451.0, 124.0, 47.0, 22.0 ],
+					"style" : "",
 					"text" : "1. 2. 3."
 				}
 
@@ -132,6 +135,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 114.0, 152.0, 19.0, 20.0 ],
+					"style" : "",
 					"text" : "Z"
 				}
 
@@ -145,6 +149,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 75.0, 152.0, 21.0, 20.0 ],
+					"style" : "",
 					"text" : "Y"
 				}
 
@@ -160,6 +165,7 @@
 					"numoutlets" : 11,
 					"outlettype" : [ "", "", "", "", "", "", "", "", "", "", "" ],
 					"patching_rect" : [ 196.0, 172.0, 126.0, 22.0 ],
+					"style" : "",
 					"text" : "ossia.list2parameter 3"
 				}
 
@@ -174,6 +180,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 391.0, 124.0, 57.0, 22.0 ],
+					"style" : "",
 					"text" : "10 20 30"
 				}
 
@@ -189,6 +196,7 @@
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "" ],
 					"patching_rect" : [ 391.0, 172.0, 118.0, 22.0 ],
+					"style" : "",
 					"text" : "ossia.remote testing",
 					"varname" : "testing"
 				}
@@ -205,6 +213,7 @@
 					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
 					"patching_rect" : [ 108.0, 171.0, 36.0, 22.0 ],
+					"style" : "",
 					"triscale" : 0.9,
 					"varname" : "Z"
 				}
@@ -221,6 +230,7 @@
 					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
 					"patching_rect" : [ 69.0, 171.0, 36.0, 22.0 ],
+					"style" : "",
 					"triscale" : 0.9,
 					"varname" : "Y"
 				}
@@ -237,6 +247,7 @@
 					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
 					"patching_rect" : [ 30.0, 171.0, 36.0, 22.0 ],
+					"style" : "",
 					"triscale" : 0.9,
 					"varname" : "X"
 				}
@@ -252,6 +263,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 306.0, 207.0, 52.0, 22.0 ],
+					"style" : "",
 					"text" : "pvar Z"
 				}
 
@@ -266,6 +278,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 251.0, 207.0, 52.0, 22.0 ],
+					"style" : "",
 					"text" : "pvar Y"
 				}
 
@@ -280,6 +293,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 196.0, 207.0, 52.0, 22.0 ],
+					"style" : "",
 					"text" : "pvar X"
 				}
 
@@ -293,6 +307,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 36.0, 152.0, 21.0, 20.0 ],
+					"style" : "",
 					"text" : "X"
 				}
 
@@ -307,6 +322,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 192.0, 116.0, 170.0, 33.0 ],
+					"style" : "",
 					"text" : "accepts up to ten inputs of any type"
 				}
 
@@ -315,7 +331,7 @@
 		"lines" : [ 			{
 				"patchline" : 				{
 					"destination" : [ "obj-10", 0 ],
-					"midpoints" : [ 510.5, 158.0, 400.5, 158.0 ],
+					"midpoints" : [ 511.5, 158.0, 400.5, 158.0 ],
 					"source" : [ "obj-1", 0 ]
 				}
 
@@ -330,7 +346,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-6", 2 ],
-					"midpoints" : [ 315.5, 243.0, 172.0, 243.0, 172.0, 155.0, 226.900000000000006, 155.0 ],
+					"midpoints" : [ 315.5, 243.0, 172.0, 243.0, 172.0, 155.0, 226.899994, 155.0 ],
 					"source" : [ "obj-14", 0 ]
 				}
 
@@ -338,7 +354,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-6", 1 ],
-					"midpoints" : [ 260.5, 237.0, 180.0, 237.0, 180.0, 161.0, 216.199999999999989, 161.0 ],
+					"midpoints" : [ 260.5, 237.0, 180.0, 237.0, 180.0, 161.0, 216.199997, 161.0 ],
 					"source" : [ "obj-15", 0 ]
 				}
 
@@ -377,7 +393,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-14", 0 ],
-					"midpoints" : [ 226.900000000000006, 199.0, 315.5, 199.0 ],
+					"midpoints" : [ 226.899994, 199.0, 315.5, 199.0 ],
 					"source" : [ "obj-6", 2 ]
 				}
 
@@ -385,7 +401,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-15", 0 ],
-					"midpoints" : [ 216.199999999999989, 203.0, 260.5, 203.0 ],
+					"midpoints" : [ 216.199997, 203.0, 260.5, 203.0 ],
 					"source" : [ "obj-6", 1 ]
 				}
 
@@ -407,7 +423,7 @@
  ],
 		"dependency_cache" : [ 			{
 				"name" : "ossia.list2parameter.maxpat",
-				"bootpath" : "~/Github/phase/ossia/ossia.list2parameter",
+				"bootpath" : "~/Github/libossia/OSSIA/ossia-max/patchers/ossia.list2parameter",
 				"patcherrelativepath" : ".",
 				"type" : "JSON",
 				"implicit" : 1

--- a/OSSIA/ossia-max/patchers/ossia.list2parameter/ossia.list2parameter.maxhelp
+++ b/OSSIA/ossia-max/patchers/ossia.list2parameter/ossia.list2parameter.maxhelp
@@ -2,13 +2,14 @@
 	"patcher" : 	{
 		"fileversion" : 1,
 		"appversion" : 		{
-			"major" : 7,
-			"minor" : 3,
-			"revision" : 5,
+			"major" : 8,
+			"minor" : 0,
+			"revision" : 6,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
+		"classnamespace" : "box",
 		"rect" : [ 100.0, 100.0, 699.0, 368.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
@@ -59,7 +60,6 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 7.0, 68.0, 542.0, 20.0 ],
-					"style" : "",
 					"text" : "Make life easier when accessing the individual members of a @type list parameter in the GUI"
 				}
 
@@ -75,7 +75,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 260.0, 308.0, 165.0, 22.0 ],
-					"style" : ""
+					"text" : "10 20 30"
 				}
 
 			}
@@ -90,7 +90,6 @@
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
 					"patching_rect" : [ 258.0, 274.0, 191.0, 22.0 ],
-					"style" : "",
 					"text" : "ossia.parameter testing @type list",
 					"varname" : "testing[1]"
 				}
@@ -106,7 +105,6 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 501.0, 124.0, 105.0, 22.0 ],
-					"style" : "",
 					"text" : "11.11 22.22 33.33"
 				}
 
@@ -121,7 +119,6 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 451.0, 124.0, 47.0, 22.0 ],
-					"style" : "",
 					"text" : "1. 2. 3."
 				}
 
@@ -135,7 +132,6 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 114.0, 152.0, 19.0, 20.0 ],
-					"style" : "",
 					"text" : "Z"
 				}
 
@@ -149,7 +145,6 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 75.0, 152.0, 21.0, 20.0 ],
-					"style" : "",
 					"text" : "Y"
 				}
 
@@ -164,9 +159,8 @@
 					"numinlets" : 11,
 					"numoutlets" : 11,
 					"outlettype" : [ "", "", "", "", "", "", "", "", "", "", "" ],
-					"patching_rect" : [ 196.0, 172.0, 174.0, 22.0 ],
-					"style" : "",
-					"text" : "ossia.list2parameter"
+					"patching_rect" : [ 196.0, 172.0, 126.0, 22.0 ],
+					"text" : "ossia.list2parameter 3"
 				}
 
 			}
@@ -180,7 +174,6 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 391.0, 124.0, 57.0, 22.0 ],
-					"style" : "",
 					"text" : "10 20 30"
 				}
 
@@ -196,7 +189,6 @@
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "" ],
 					"patching_rect" : [ 391.0, 172.0, 118.0, 22.0 ],
-					"style" : "",
 					"text" : "ossia.remote testing",
 					"varname" : "testing"
 				}
@@ -213,7 +205,6 @@
 					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
 					"patching_rect" : [ 108.0, 171.0, 36.0, 22.0 ],
-					"style" : "",
 					"triscale" : 0.9,
 					"varname" : "Z"
 				}
@@ -230,7 +221,6 @@
 					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
 					"patching_rect" : [ 69.0, 171.0, 36.0, 22.0 ],
-					"style" : "",
 					"triscale" : 0.9,
 					"varname" : "Y"
 				}
@@ -247,7 +237,6 @@
 					"outlettype" : [ "", "bang" ],
 					"parameter_enable" : 0,
 					"patching_rect" : [ 30.0, 171.0, 36.0, 22.0 ],
-					"style" : "",
 					"triscale" : 0.9,
 					"varname" : "X"
 				}
@@ -263,7 +252,6 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 306.0, 207.0, 52.0, 22.0 ],
-					"style" : "",
 					"text" : "pvar Z"
 				}
 
@@ -278,7 +266,6 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 251.0, 207.0, 52.0, 22.0 ],
-					"style" : "",
 					"text" : "pvar Y"
 				}
 
@@ -293,7 +280,6 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 196.0, 207.0, 52.0, 22.0 ],
-					"style" : "",
 					"text" : "pvar X"
 				}
 
@@ -307,7 +293,6 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 36.0, 152.0, 21.0, 20.0 ],
-					"style" : "",
 					"text" : "X"
 				}
 
@@ -322,7 +307,6 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 192.0, 116.0, 170.0, 33.0 ],
-					"style" : "",
 					"text" : "accepts up to ten inputs of any type"
 				}
 
@@ -346,7 +330,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-6", 2 ],
-					"midpoints" : [ 315.5, 243.0, 172.0, 243.0, 172.0, 155.0, 236.5, 155.0 ],
+					"midpoints" : [ 315.5, 243.0, 172.0, 243.0, 172.0, 155.0, 226.900000000000006, 155.0 ],
 					"source" : [ "obj-14", 0 ]
 				}
 
@@ -354,7 +338,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-6", 1 ],
-					"midpoints" : [ 260.5, 237.0, 180.0, 237.0, 180.0, 161.0, 221.0, 161.0 ],
+					"midpoints" : [ 260.5, 237.0, 180.0, 237.0, 180.0, 161.0, 216.199999999999989, 161.0 ],
 					"source" : [ "obj-15", 0 ]
 				}
 
@@ -393,7 +377,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-14", 0 ],
-					"midpoints" : [ 236.5, 199.0, 315.5, 199.0 ],
+					"midpoints" : [ 226.900000000000006, 199.0, 315.5, 199.0 ],
 					"source" : [ "obj-6", 2 ]
 				}
 
@@ -401,7 +385,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-15", 0 ],
-					"midpoints" : [ 221.0, 203.0, 260.5, 203.0 ],
+					"midpoints" : [ 216.199999999999989, 203.0, 260.5, 203.0 ],
 					"source" : [ "obj-6", 1 ]
 				}
 
@@ -423,7 +407,7 @@
  ],
 		"dependency_cache" : [ 			{
 				"name" : "ossia.list2parameter.maxpat",
-				"bootpath" : "~/Github/TML-depo/TML-code/ossia/ossia.list2parameter",
+				"bootpath" : "~/Github/phase/ossia/ossia.list2parameter",
 				"patcherrelativepath" : ".",
 				"type" : "JSON",
 				"implicit" : 1

--- a/OSSIA/ossia-max/patchers/ossia.list2parameter/ossia.list2parameter.maxpat
+++ b/OSSIA/ossia-max/patchers/ossia.list2parameter/ossia.list2parameter.maxpat
@@ -38,500 +38,388 @@
 		"subpatcher_template" : "evan",
 		"boxes" : [ 			{
 				"box" : 				{
-					"id" : "obj-27",
-					"linecount" : 2,
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 30.0, 15.0, 150.0, 33.0 ],
-					"style" : "",
-					"text" : "replacement for j.list2parameter"
+					"comment" : "list member 9",
+					"id" : "obj-1",
+					"index" : 10,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 201.0, 273.0, 15.0, 15.0 ],
+					"style" : ""
 				}
 
 			}
 , 			{
 				"box" : 				{
+					"comment" : "list member 9",
+					"id" : "obj-2",
+					"index" : 10,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 201.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 6",
+					"id" : "obj-3",
+					"index" : 7,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 138.0, 273.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 7",
+					"id" : "obj-4",
+					"index" : 8,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 159.0, 273.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 8",
+					"id" : "obj-5",
+					"index" : 9,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 180.0, 273.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 8",
+					"id" : "obj-6",
+					"index" : 9,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 180.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 7",
+					"id" : "obj-7",
+					"index" : 8,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 159.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 6",
+					"id" : "obj-8",
+					"index" : 7,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 138.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 3",
+					"id" : "obj-9",
+					"index" : 4,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 74.0, 273.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 4",
+					"id" : "obj-10",
+					"index" : 5,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 95.0, 273.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 5",
+					"id" : "obj-11",
+					"index" : 6,
+					"maxclass" : "inlet",
+					"numinlets" : 0,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 116.0, 273.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 5",
+					"id" : "obj-12",
+					"index" : 6,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 116.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 4",
+					"id" : "obj-13",
+					"index" : 5,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 95.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 3",
+					"id" : "obj-14",
+					"index" : 4,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 74.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"fontname" : "Verdana",
+					"fontsize" : 10.0,
+					"id" : "obj-15",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 255.0, 427.0, 60.0, 21.0 ],
+					"style" : "",
+					"text" : "zl slice #1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"fontname" : "Verdana",
+					"fontsize" : 10.0,
+					"id" : "obj-16",
+					"maxclass" : "newobj",
+					"numinlets" : 11,
+					"numoutlets" : 11,
+					"outlettype" : [ "", "", "", "", "", "", "", "", "", "", "" ],
+					"patching_rect" : [ 255.0, 130.0, 207.0, 21.0 ],
+					"style" : "",
+					"text" : "route 0 1 2 3 4 5 6 7 8 9"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"fontname" : "Verdana",
+					"fontsize" : 10.0,
 					"id" : "obj-17",
 					"maxclass" : "message",
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 855.0, 150.0, 43.0, 22.0 ],
-					"presentation_rect" : [ 856.0, 169.0, 0.0, 0.0 ],
+					"patching_rect" : [ 255.0, 107.0, 56.0, 21.0 ],
 					"style" : "",
-					"text" : "set $1"
+					"text" : "$1 set $2"
 				}
 
 			}
 , 			{
 				"box" : 				{
+					"fontname" : "Verdana",
+					"fontsize" : 10.0,
 					"id" : "obj-18",
-					"maxclass" : "message",
-					"numinlets" : 2,
+					"maxclass" : "newobj",
+					"numinlets" : 1,
 					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 765.0, 150.0, 43.0, 22.0 ],
-					"presentation_rect" : [ 766.0, 169.0, 0.0, 0.0 ],
+					"outlettype" : [ "list" ],
+					"patching_rect" : [ 255.0, 82.0, 54.0, 21.0 ],
 					"style" : "",
-					"text" : "set $1"
+					"text" : "listfunnel"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"comment" : "",
+					"fontface" : 0,
+					"fontname" : "Verdana",
+					"fontsize" : 10.0,
 					"id" : "obj-19",
-					"index" : 9,
-					"maxclass" : "inlet",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 735.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 736.0, 214.0, 0.0, 0.0 ],
-					"style" : ""
+					"maxclass" : "newobj",
+					"numinlets" : 3,
+					"numoutlets" : 3,
+					"outlettype" : [ "", "", "" ],
+					"patching_rect" : [ 255.0, 45.0, 89.0, 21.0 ],
+					"style" : "",
+					"text" : "route set setlist"
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"comment" : "",
+					"fontname" : "Verdana",
+					"fontsize" : 10.0,
 					"id" : "obj-20",
-					"index" : 10,
-					"maxclass" : "inlet",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 825.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 826.0, 214.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-21",
-					"index" : 9,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 780.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 781.0, 214.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-22",
-					"index" : 10,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 870.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 871.0, 214.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-11",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 675.0, 150.0, 43.0, 22.0 ],
-					"presentation_rect" : [ 680.0, 166.0, 0.0, 0.0 ],
-					"style" : "",
-					"text" : "set $1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-12",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 585.0, 150.0, 43.0, 22.0 ],
-					"presentation_rect" : [ 590.0, 166.0, 0.0, 0.0 ],
-					"style" : "",
-					"text" : "set $1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-13",
-					"index" : 7,
-					"maxclass" : "inlet",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 555.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 560.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-14",
-					"index" : 8,
-					"maxclass" : "inlet",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 645.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 650.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-15",
-					"index" : 7,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 600.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 605.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-16",
-					"index" : 8,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 690.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 695.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-1",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 495.0, 150.0, 43.0, 22.0 ],
-					"presentation_rect" : [ 498.0, 166.0, 0.0, 0.0 ],
-					"style" : "",
-					"text" : "set $1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-2",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 405.0, 150.0, 43.0, 22.0 ],
-					"presentation_rect" : [ 408.0, 166.0, 0.0, 0.0 ],
-					"style" : "",
-					"text" : "set $1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-3",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 315.0, 150.0, 43.0, 22.0 ],
-					"presentation_rect" : [ 318.0, 166.0, 0.0, 0.0 ],
-					"style" : "",
-					"text" : "set $1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-4",
-					"index" : 4,
-					"maxclass" : "inlet",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 285.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 288.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-5",
-					"index" : 5,
-					"maxclass" : "inlet",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 375.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 378.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-6",
-					"index" : 6,
-					"maxclass" : "inlet",
-					"numinlets" : 0,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 465.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 468.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-7",
-					"index" : 4,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 330.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 333.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-8",
-					"index" : 5,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 420.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 423.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-10",
-					"index" : 6,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 510.0, 195.0, 30.0, 30.0 ],
-					"presentation_rect" : [ 513.0, 211.0, 0.0, 0.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-54",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 11,
-					"outlettype" : [ "", "", "", "", "", "", "", "", "", "", "" ],
-					"patching_rect" : [ 45.0, 105.0, 915.0, 22.0 ],
-					"style" : "",
-					"text" : "unjoin 10"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-53",
-					"maxclass" : "newobj",
-					"numinlets" : 2,
-					"numoutlets" : 2,
-					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 45.0, 75.0, 57.0, 22.0 ],
-					"style" : "",
-					"text" : "route set"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-50",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 225.0, 150.0, 43.0, 22.0 ],
-					"style" : "",
-					"text" : "set $1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-49",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 135.0, 150.0, 43.0, 22.0 ],
-					"style" : "",
-					"text" : "set $1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-48",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 45.0, 150.0, 43.0, 22.0 ],
-					"style" : "",
-					"text" : "set $1"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-9",
 					"maxclass" : "newobj",
 					"numinlets" : 10,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 15.0, 255.0, 825.0, 22.0 ],
+					"patching_rect" : [ 255.0, 400.0, 184.0, 21.0 ],
 					"style" : "",
-					"text" : "join 10 @triggers -1"
+					"text" : "pak 0. 0. 0. 0. 0. 0. 0. 0. 0. 0."
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"comment" : "",
-					"id" : "obj-69",
+					"comment" : "from j.parameter",
+					"id" : "obj-21",
 					"index" : 11,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 930.0, 15.0, 30.0, 30.0 ],
+					"patching_rect" : [ 255.0, 15.0, 25.0, 25.0 ],
 					"style" : ""
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"comment" : "",
-					"id" : "obj-70",
+					"comment" : "list member 0",
+					"id" : "obj-22",
 					"index" : 1,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 15.0, 195.0, 30.0, 30.0 ],
+					"patching_rect" : [ 10.0, 273.0, 15.0, 15.0 ],
 					"style" : ""
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"comment" : "",
-					"id" : "obj-71",
+					"comment" : "list member 1",
+					"id" : "obj-23",
 					"index" : 2,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 105.0, 195.0, 30.0, 30.0 ],
+					"patching_rect" : [ 31.0, 273.0, 15.0, 15.0 ],
 					"style" : ""
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"comment" : "",
-					"id" : "obj-72",
+					"comment" : "list member 2",
+					"id" : "obj-24",
 					"index" : 3,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 195.0, 195.0, 30.0, 30.0 ],
+					"patching_rect" : [ 52.0, 273.0, 15.0, 15.0 ],
 					"style" : ""
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"comment" : "",
-					"id" : "obj-73",
-					"index" : 1,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 60.0, 195.0, 30.0, 30.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-74",
+					"comment" : "to j.parameter",
+					"id" : "obj-25",
 					"index" : 11,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 930.0, 315.0, 30.0, 30.0 ],
+					"patching_rect" : [ 255.0, 475.0, 25.0, 25.0 ],
 					"style" : ""
 				}
 
 			}
 , 			{
 				"box" : 				{
-					"comment" : "",
-					"id" : "obj-75",
-					"index" : 2,
-					"maxclass" : "outlet",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 150.0, 195.0, 30.0, 30.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"comment" : "",
-					"id" : "obj-76",
+					"comment" : "list member 2",
+					"id" : "obj-26",
 					"index" : 3,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 240.0, 195.0, 30.0, 30.0 ],
+					"patching_rect" : [ 52.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 1",
+					"id" : "obj-27",
+					"index" : 2,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 31.0, 244.0, 15.0, 15.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"comment" : "list member 0",
+					"id" : "obj-28",
+					"index" : 1,
+					"maxclass" : "outlet",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 10.0, 244.0, 15.0, 15.0 ],
 					"style" : ""
 				}
 
@@ -539,353 +427,281 @@
  ],
 		"lines" : [ 			{
 				"patchline" : 				{
-					"destination" : [ "obj-10", 0 ],
-					"midpoints" : [ 504.5, 183.0, 519.5, 183.0 ],
-					"order" : 0,
+					"destination" : [ "obj-20", 9 ],
 					"source" : [ "obj-1", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-9", 5 ],
-					"midpoints" : [ 504.5, 240.0, 472.277778, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-1", 0 ]
+					"destination" : [ "obj-20", 4 ],
+					"source" : [ "obj-10", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-16", 0 ],
-					"midpoints" : [ 684.5, 183.0, 699.5, 183.0 ],
-					"order" : 0,
+					"destination" : [ "obj-20", 5 ],
 					"source" : [ "obj-11", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-9", 7 ],
-					"midpoints" : [ 684.5, 240.0, 651.388889, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-11", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-15", 0 ],
-					"midpoints" : [ 594.5, 183.0, 609.5, 183.0 ],
-					"order" : 0,
-					"source" : [ "obj-12", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 6 ],
-					"midpoints" : [ 594.5, 240.0, 561.833333, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-12", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 6 ],
-					"midpoints" : [ 564.5, 239.5, 561.833333, 239.5 ],
-					"source" : [ "obj-13", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 7 ],
-					"midpoints" : [ 654.5, 239.5, 651.388889, 239.5 ],
-					"source" : [ "obj-14", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-22", 0 ],
-					"midpoints" : [ 864.5, 183.0, 879.5, 183.0 ],
-					"order" : 0,
-					"source" : [ "obj-17", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 9 ],
-					"midpoints" : [ 864.5, 240.0, 830.5, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-17", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-21", 0 ],
-					"midpoints" : [ 774.5, 183.0, 789.5, 183.0 ],
-					"order" : 0,
-					"source" : [ "obj-18", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 8 ],
-					"midpoints" : [ 774.5, 240.0, 740.944444, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-18", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 8 ],
-					"midpoints" : [ 744.5, 239.5, 740.944444, 239.5 ],
-					"source" : [ "obj-19", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-8", 0 ],
-					"midpoints" : [ 414.5, 183.0, 429.5, 183.0 ],
-					"order" : 0,
-					"source" : [ "obj-2", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 4 ],
-					"midpoints" : [ 414.5, 240.0, 382.722222, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-2", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 9 ],
-					"midpoints" : [ 834.5, 239.5, 830.5, 239.5 ],
-					"source" : [ "obj-20", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-7", 0 ],
-					"midpoints" : [ 324.5, 183.0, 339.5, 183.0 ],
-					"order" : 0,
-					"source" : [ "obj-3", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 3 ],
-					"midpoints" : [ 324.5, 240.0, 293.166667, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-3", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 3 ],
-					"midpoints" : [ 294.5, 249.0, 293.166667, 249.0 ],
-					"source" : [ "obj-4", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-73", 0 ],
-					"midpoints" : [ 54.5, 183.0, 69.5, 183.0 ],
-					"order" : 0,
-					"source" : [ "obj-48", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 0 ],
-					"midpoints" : [ 54.5, 240.0, 24.5, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-48", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-75", 0 ],
-					"order" : 0,
-					"source" : [ "obj-49", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 1 ],
-					"midpoints" : [ 144.5, 240.0, 114.055556, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-49", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 4 ],
-					"midpoints" : [ 384.5, 239.5, 382.722222, 239.5 ],
-					"source" : [ "obj-5", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-76", 0 ],
-					"midpoints" : [ 234.5, 183.0, 249.5, 183.0 ],
-					"order" : 0,
-					"source" : [ "obj-50", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-9", 2 ],
-					"midpoints" : [ 234.5, 240.0, 203.611111, 240.0 ],
-					"order" : 1,
-					"source" : [ "obj-50", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-54", 0 ],
-					"source" : [ "obj-53", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-1", 0 ],
-					"source" : [ "obj-54", 5 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-11", 0 ],
-					"source" : [ "obj-54", 7 ]
+					"destination" : [ "obj-25", 0 ],
+					"source" : [ "obj-15", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-12", 0 ],
-					"source" : [ "obj-54", 6 ]
+					"order" : 1,
+					"source" : [ "obj-16", 5 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-17", 0 ],
-					"source" : [ "obj-54", 9 ]
+					"destination" : [ "obj-13", 0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 4 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-18", 0 ],
-					"source" : [ "obj-54", 8 ]
+					"destination" : [ "obj-14", 0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 3 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-2", 0 ],
-					"source" : [ "obj-54", 4 ]
+					"midpoints" : [ 452.0, 135.0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 9 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-3", 0 ],
-					"source" : [ "obj-54", 3 ]
+					"destination" : [ "obj-20", 9 ],
+					"order" : 0,
+					"source" : [ "obj-16", 9 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-48", 0 ],
-					"midpoints" : [ 54.5, 138.0, 54.5, 138.0 ],
-					"source" : [ "obj-54", 0 ]
+					"destination" : [ "obj-20", 8 ],
+					"order" : 0,
+					"source" : [ "obj-16", 8 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-49", 0 ],
-					"midpoints" : [ 144.1, 138.0, 144.5, 138.0 ],
-					"source" : [ "obj-54", 1 ]
+					"destination" : [ "obj-20", 7 ],
+					"order" : 0,
+					"source" : [ "obj-16", 7 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-50", 0 ],
-					"midpoints" : [ 233.7, 138.0, 234.5, 138.0 ],
-					"source" : [ "obj-54", 2 ]
+					"destination" : [ "obj-20", 6 ],
+					"order" : 0,
+					"source" : [ "obj-16", 6 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-9", 5 ],
-					"midpoints" : [ 474.5, 239.5, 472.277778, 239.5 ],
-					"source" : [ "obj-6", 0 ]
+					"destination" : [ "obj-20", 5 ],
+					"order" : 0,
+					"source" : [ "obj-16", 5 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-53", 0 ],
-					"midpoints" : [ 939.5, 59.5, 54.5, 59.5 ],
-					"source" : [ "obj-69", 0 ]
+					"destination" : [ "obj-20", 4 ],
+					"order" : 0,
+					"source" : [ "obj-16", 4 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-9", 0 ],
-					"source" : [ "obj-70", 0 ]
+					"destination" : [ "obj-20", 3 ],
+					"order" : 0,
+					"source" : [ "obj-16", 3 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-9", 1 ],
-					"source" : [ "obj-71", 0 ]
+					"destination" : [ "obj-20", 2 ],
+					"order" : 0,
+					"source" : [ "obj-16", 2 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-9", 2 ],
-					"midpoints" : [ 204.5, 249.0, 203.611111, 249.0 ],
-					"source" : [ "obj-72", 0 ]
+					"destination" : [ "obj-20", 1 ],
+					"order" : 0,
+					"source" : [ "obj-16", 1 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-74", 0 ],
-					"midpoints" : [ 24.5, 288.0, 939.5, 288.0 ],
+					"destination" : [ "obj-20", 0 ],
+					"order" : 0,
+					"source" : [ "obj-16", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-26", 0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-27", 0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-28", 0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-6", 0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 8 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-7", 0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 7 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-8", 0 ],
+					"order" : 1,
+					"source" : [ "obj-16", 6 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-16", 0 ],
+					"source" : [ "obj-17", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-17", 0 ],
+					"source" : [ "obj-18", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-18", 0 ],
+					"midpoints" : [ 299.5, 73.5, 264.5, 73.5 ],
+					"source" : [ "obj-19", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-18", 0 ],
+					"source" : [ "obj-19", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-15", 0 ],
+					"source" : [ "obj-20", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-19", 0 ],
+					"source" : [ "obj-21", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-20", 0 ],
+					"source" : [ "obj-22", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-20", 1 ],
+					"source" : [ "obj-23", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-20", 2 ],
+					"source" : [ "obj-24", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-20", 6 ],
+					"source" : [ "obj-3", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-20", 7 ],
+					"source" : [ "obj-4", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-20", 8 ],
+					"source" : [ "obj-5", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-20", 3 ],
 					"source" : [ "obj-9", 0 ]
 				}
 

--- a/OSSIA/ossia-max/patchers/ossia.list2parameter/ossia.list2parameter.maxpat
+++ b/OSSIA/ossia-max/patchers/ossia.list2parameter/ossia.list2parameter.maxpat
@@ -5,7 +5,7 @@
 			"major" : 7,
 			"minor" : 3,
 			"revision" : 5,
-			"architecture" : "x64",
+			"architecture" : "x86",
 			"modernui" : 1
 		}
 ,
@@ -40,7 +40,7 @@
 				"box" : 				{
 					"comment" : "list member 9",
 					"id" : "obj-1",
-					"index" : 10,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -54,7 +54,7 @@
 				"box" : 				{
 					"comment" : "list member 9",
 					"id" : "obj-2",
-					"index" : 10,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -67,7 +67,7 @@
 				"box" : 				{
 					"comment" : "list member 6",
 					"id" : "obj-3",
-					"index" : 7,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -81,7 +81,7 @@
 				"box" : 				{
 					"comment" : "list member 7",
 					"id" : "obj-4",
-					"index" : 8,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -95,7 +95,7 @@
 				"box" : 				{
 					"comment" : "list member 8",
 					"id" : "obj-5",
-					"index" : 9,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -109,7 +109,7 @@
 				"box" : 				{
 					"comment" : "list member 8",
 					"id" : "obj-6",
-					"index" : 9,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -122,7 +122,7 @@
 				"box" : 				{
 					"comment" : "list member 7",
 					"id" : "obj-7",
-					"index" : 8,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -135,7 +135,7 @@
 				"box" : 				{
 					"comment" : "list member 6",
 					"id" : "obj-8",
-					"index" : 7,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -148,7 +148,7 @@
 				"box" : 				{
 					"comment" : "list member 3",
 					"id" : "obj-9",
-					"index" : 4,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -162,7 +162,7 @@
 				"box" : 				{
 					"comment" : "list member 4",
 					"id" : "obj-10",
-					"index" : 5,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -176,7 +176,7 @@
 				"box" : 				{
 					"comment" : "list member 5",
 					"id" : "obj-11",
-					"index" : 6,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -190,7 +190,7 @@
 				"box" : 				{
 					"comment" : "list member 5",
 					"id" : "obj-12",
-					"index" : 6,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -203,7 +203,7 @@
 				"box" : 				{
 					"comment" : "list member 4",
 					"id" : "obj-13",
-					"index" : 5,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -216,7 +216,7 @@
 				"box" : 				{
 					"comment" : "list member 3",
 					"id" : "obj-14",
-					"index" : 4,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -320,7 +320,7 @@
 				"box" : 				{
 					"comment" : "from j.parameter",
 					"id" : "obj-21",
-					"index" : 11,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -334,7 +334,7 @@
 				"box" : 				{
 					"comment" : "list member 0",
 					"id" : "obj-22",
-					"index" : 1,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -348,7 +348,7 @@
 				"box" : 				{
 					"comment" : "list member 1",
 					"id" : "obj-23",
-					"index" : 2,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -362,7 +362,7 @@
 				"box" : 				{
 					"comment" : "list member 2",
 					"id" : "obj-24",
-					"index" : 3,
+					"index" : 0,
 					"maxclass" : "inlet",
 					"numinlets" : 0,
 					"numoutlets" : 1,
@@ -376,7 +376,7 @@
 				"box" : 				{
 					"comment" : "to j.parameter",
 					"id" : "obj-25",
-					"index" : 11,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -389,7 +389,7 @@
 				"box" : 				{
 					"comment" : "list member 2",
 					"id" : "obj-26",
-					"index" : 3,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -402,7 +402,7 @@
 				"box" : 				{
 					"comment" : "list member 1",
 					"id" : "obj-27",
-					"index" : 2,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -415,7 +415,7 @@
 				"box" : 				{
 					"comment" : "list member 0",
 					"id" : "obj-28",
-					"index" : 1,
+					"index" : 0,
 					"maxclass" : "outlet",
 					"numinlets" : 1,
 					"numoutlets" : 0,
@@ -706,7 +706,9 @@
 				}
 
 			}
- ]
+ ],
+		"dependency_cache" : [  ],
+		"autosave" : 0
 	}
 
 }


### PR DESCRIPTION
I realized that the way j.list2parameter worked made more sense than my attempt at recreating it, so ossia.list2parameter is now just the same as j.list2parameter. There were conflicts the first time, so I'm trying this again..