### PR TITLE
Hotfix/565 keep range values order

### DIFF
--- a/src/ossia-max/CMakeLists.txt
+++ b/src/ossia-max/CMakeLists.txt
@@ -246,6 +246,7 @@ if(OSSIA_MAX_TEST)
         ${CMAKE_CURRENT_LIST_DIR}/max-test/559-ghost_doublon.maxtest.maxpat
         ${CMAKE_CURRENT_LIST_DIR}/max-test/545-bind_remote_without_args.maxpat
         ${CMAKE_CURRENT_LIST_DIR}/max-test/542-mute.maxpat
+        ${CMAKE_CURRENT_LIST_DIR}/max-test/565-range_values_order.maxtest.maxpat
 
         # test dependencies
         ${CMAKE_CURRENT_LIST_DIR}/max-test/559-master_subpatcher.maxpat

--- a/src/ossia-max/max-test/565-range_values_order.maxtest.maxpat
+++ b/src/ossia-max/max-test/565-range_values_order.maxtest.maxpat
@@ -40,6 +40,18 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"patching_rect" : [ 294.0, 76.0, 48.0, 22.0 ],
+					"text" : "del 100"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"checkedcolor" : [ 0.0, 1.0, 0.0, 1.0 ],
 					"id" : "obj-19",
 					"maxclass" : "toggle",
@@ -47,7 +59,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "int" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 566.0, 269.0, 24.0, 24.0 ],
+					"patching_rect" : [ 566.0, 314.0, 24.0, 24.0 ],
 					"uncheckedcolor" : [ 0.996078431372549, 0.0, 0.0, 1.0 ]
 				}
 
@@ -60,7 +72,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 566.0, 227.0, 249.0, 35.0 ],
+					"patching_rect" : [ 566.0, 272.0, 249.0, 35.0 ],
 					"text" : "zl compare Zero Uno Dos Tres Cuatro Cinco Seis Siete"
 				}
 
@@ -73,20 +85,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 566.0, 299.0, 145.0, 22.0 ],
+					"patching_rect" : [ 566.0, 344.0, 145.0, 22.0 ],
 					"text" : "test.assert \"Range Order\""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-17",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 502.0, 163.0, 266.0, 22.0 ],
-					"text" : "Cinco Cuatro Dos Seis Siete Tres Uno Zero"
 				}
 
 			}
@@ -97,7 +97,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 339.0, 191.0, 37.0, 22.0 ],
+					"patching_rect" : [ 339.0, 236.0, 37.0, 22.0 ],
 					"text" : "zl.rev"
 				}
 
@@ -109,7 +109,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 452.0, 245.0, 35.0, 22.0 ],
+					"patching_rect" : [ 452.0, 290.0, 35.0, 22.0 ],
 					"text" : "clear"
 				}
 
@@ -121,7 +121,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 294.0, 32.0, 58.0, 22.0 ],
+					"patching_rect" : [ 294.0, 45.0, 58.0, 22.0 ],
 					"text" : "loadbang"
 				}
 
@@ -133,7 +133,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 339.0, 245.0, 96.0, 22.0 ],
+					"patching_rect" : [ 339.0, 290.0, 96.0, 22.0 ],
 					"text" : "prepend append"
 				}
 
@@ -145,7 +145,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "bang", "", "clear" ],
-					"patching_rect" : [ 320.0, 163.0, 57.0, 22.0 ],
+					"patching_rect" : [ 320.0, 208.0, 57.0, 22.0 ],
 					"text" : "t b l clear"
 				}
 
@@ -157,7 +157,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 339.0, 217.0, 47.0, 22.0 ],
+					"patching_rect" : [ 339.0, 262.0, 47.0, 22.0 ],
 					"text" : "zl.iter 1"
 				}
 
@@ -169,7 +169,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 2,
 					"outlettype" : [ "", "" ],
-					"patching_rect" : [ 320.0, 136.0, 70.0, 22.0 ],
+					"patching_rect" : [ 320.0, 181.0, 70.0, 22.0 ],
 					"text" : "route range"
 				}
 
@@ -181,7 +181,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 294.0, 66.0, 59.0, 22.0 ],
+					"patching_rect" : [ 294.0, 111.0, 59.0, 22.0 ],
 					"text" : "get range"
 				}
 
@@ -192,13 +192,13 @@
 					"fontname" : "Arial",
 					"fontsize" : 13.0,
 					"id" : "obj-44",
-					"items" : [ "Zero", ",", "Uno", ",", "Tres", ",", "Siete", ",", "Seis", ",", "Dos", ",", "Cuatro", ",", "Cinco" ],
+					"items" : [ "Siete", ",", "Seis", ",", "Cinco", ",", "Cuatro", ",", "Tres", ",", "Dos", ",", "Uno", ",", "Zero" ],
 					"maxclass" : "umenu",
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "int", "", "" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 294.0, 281.734161376953125, 99.0, 23.0 ]
+					"patching_rect" : [ 294.0, 326.734161376953125, 99.0, 23.0 ]
 				}
 
 			}
@@ -210,7 +210,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "" ],
-					"patching_rect" : [ 294.0, 106.0, 206.0, 22.0 ],
+					"patching_rect" : [ 294.0, 151.0, 206.0, 22.0 ],
 					"text" : "ossia.remote submodel/string_param"
 				}
 
@@ -359,7 +359,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 45.0, 331.234161376953125, 557.0, 218.765838623046875 ],
+					"patching_rect" : [ 45.0, 376.234161376953125, 557.0, 218.765838623046875 ],
 					"viewvisibility" : 1
 				}
 
@@ -371,7 +371,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 65.0, 77.0, 106.0, 22.0 ],
+					"patching_rect" : [ 65.0, 122.0, 106.0, 22.0 ],
 					"text" : "ossia.device basic"
 				}
 
@@ -421,15 +421,22 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-10", 0 ],
+					"destination" : [ "obj-4", 0 ],
 					"source" : [ "obj-2", 0 ]
 				}
 
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-10", 0 ],
+					"source" : [ "obj-4", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-11", 0 ],
-					"midpoints" : [ 343.5, 315.734161376953125, 266.5, 315.734161376953125, 266.5, 95.0, 303.5, 95.0 ],
+					"midpoints" : [ 343.5, 360.734161376953125, 266.5, 360.734161376953125, 266.5, 140.0, 303.5, 140.0 ],
 					"source" : [ "obj-44", 1 ]
 				}
 
@@ -451,14 +458,6 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-14", 0 ],
-					"order" : 1,
-					"source" : [ "obj-7", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-17", 1 ],
 					"order" : 0,
 					"source" : [ "obj-7", 0 ]
 				}
@@ -467,7 +466,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-8", 0 ],
-					"order" : 2,
+					"order" : 1,
 					"source" : [ "obj-7", 0 ]
 				}
 
@@ -475,7 +474,7 @@
 , 			{
 				"patchline" : 				{
 					"destination" : [ "obj-11", 0 ],
-					"midpoints" : [ 329.5, 208.0, 278.5, 208.0, 278.5, 95.0, 303.5, 95.0 ],
+					"midpoints" : [ 329.5, 253.0, 278.5, 253.0, 278.5, 140.0, 303.5, 140.0 ],
 					"source" : [ "obj-8", 0 ]
 				}
 

--- a/src/ossia-max/max-test/565-range_values_order.maxtest.maxpat
+++ b/src/ossia-max/max-test/565-range_values_order.maxtest.maxpat
@@ -1,0 +1,539 @@
+{
+	"patcher" : 	{
+		"fileversion" : 1,
+		"appversion" : 		{
+			"major" : 8,
+			"minor" : 1,
+			"revision" : 5,
+			"architecture" : "x64",
+			"modernui" : 1
+		}
+,
+		"classnamespace" : "box",
+		"rect" : [ 465.0, 136.0, 828.0, 608.0 ],
+		"bglocked" : 0,
+		"openinpresentation" : 0,
+		"default_fontsize" : 12.0,
+		"default_fontface" : 0,
+		"default_fontname" : "Arial",
+		"gridonopen" : 1,
+		"gridsize" : [ 15.0, 15.0 ],
+		"gridsnaponopen" : 1,
+		"objectsnaponopen" : 1,
+		"statusbarvisible" : 2,
+		"toolbarvisible" : 1,
+		"lefttoolbarpinned" : 0,
+		"toptoolbarpinned" : 0,
+		"righttoolbarpinned" : 0,
+		"bottomtoolbarpinned" : 0,
+		"toolbars_unpinned_last_save" : 0,
+		"tallnewobj" : 0,
+		"boxanimatetime" : 200,
+		"enablehscroll" : 1,
+		"enablevscroll" : 1,
+		"devicewidth" : 0.0,
+		"description" : "",
+		"digest" : "",
+		"tags" : "",
+		"style" : "",
+		"subpatcher_template" : "",
+		"assistshowspatchername" : 0,
+		"boxes" : [ 			{
+				"box" : 				{
+					"checkedcolor" : [ 0.0, 1.0, 0.0, 1.0 ],
+					"id" : "obj-19",
+					"maxclass" : "toggle",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "int" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 566.0, 269.0, 24.0, 24.0 ],
+					"uncheckedcolor" : [ 0.996078431372549, 0.0, 0.0, 1.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-14",
+					"linecount" : 2,
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 566.0, 227.0, 249.0, 35.0 ],
+					"text" : "zl compare Zero Uno Dos Tres Cuatro Cinco Seis Siete"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.7, 0.4, 0.3, 1.0 ],
+					"id" : "obj-3",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 566.0, 299.0, 145.0, 22.0 ],
+					"text" : "test.assert \"Range Order\""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 502.0, 163.0, 266.0, 22.0 ],
+					"text" : "Cinco Cuatro Dos Seis Siete Tres Uno Zero"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 339.0, 191.0, 37.0, 22.0 ],
+					"text" : "zl.rev"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-5",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 452.0, 245.0, 35.0, 22.0 ],
+					"text" : "clear"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "bang" ],
+					"patching_rect" : [ 294.0, 32.0, 58.0, 22.0 ],
+					"text" : "loadbang"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 339.0, 245.0, 96.0, 22.0 ],
+					"text" : "prepend append"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "bang", "", "clear" ],
+					"patching_rect" : [ 320.0, 163.0, 57.0, 22.0 ],
+					"text" : "t b l clear"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-6",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 339.0, 217.0, 47.0, 22.0 ],
+					"text" : "zl.iter 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-7",
+					"maxclass" : "newobj",
+					"numinlets" : 2,
+					"numoutlets" : 2,
+					"outlettype" : [ "", "" ],
+					"patching_rect" : [ 320.0, 136.0, 70.0, 22.0 ],
+					"text" : "route range"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-10",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 294.0, 66.0, 59.0, 22.0 ],
+					"text" : "get range"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"fontface" : 0,
+					"fontname" : "Arial",
+					"fontsize" : 13.0,
+					"id" : "obj-44",
+					"items" : [ "Zero", ",", "Uno", ",", "Tres", ",", "Siete", ",", "Seis", ",", "Dos", ",", "Cuatro", ",", "Cinco" ],
+					"maxclass" : "umenu",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "int", "", "" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 294.0, 281.734161376953125, 99.0, 23.0 ]
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"color" : [ 0.12549, 0.796078, 0.894118, 1.0 ],
+					"id" : "obj-11",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 3,
+					"outlettype" : [ "", "", "" ],
+					"patching_rect" : [ 294.0, 106.0, 206.0, 22.0 ],
+					"text" : "ossia.remote submodel/string_param"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"bgmode" : 2,
+					"border" : 0,
+					"clickthrough" : 0,
+					"embed" : 1,
+					"enablehscroll" : 0,
+					"enablevscroll" : 0,
+					"id" : "obj-13",
+					"lockeddragscroll" : 0,
+					"maxclass" : "bpatcher",
+					"numinlets" : 0,
+					"numoutlets" : 0,
+					"offset" : [ 0.0, 0.0 ],
+					"patcher" : 					{
+						"fileversion" : 1,
+						"appversion" : 						{
+							"major" : 8,
+							"minor" : 1,
+							"revision" : 5,
+							"architecture" : "x64",
+							"modernui" : 1
+						}
+,
+						"classnamespace" : "box",
+						"rect" : [ 331.0, 450.0, 640.0, 241.0 ],
+						"bglocked" : 0,
+						"openinpresentation" : 0,
+						"default_fontsize" : 12.0,
+						"default_fontface" : 0,
+						"default_fontname" : "Arial",
+						"gridonopen" : 1,
+						"gridsize" : [ 15.0, 15.0 ],
+						"gridsnaponopen" : 1,
+						"objectsnaponopen" : 1,
+						"statusbarvisible" : 2,
+						"toolbarvisible" : 1,
+						"lefttoolbarpinned" : 0,
+						"toptoolbarpinned" : 0,
+						"righttoolbarpinned" : 0,
+						"bottomtoolbarpinned" : 0,
+						"toolbars_unpinned_last_save" : 0,
+						"tallnewobj" : 0,
+						"boxanimatetime" : 200,
+						"enablehscroll" : 1,
+						"enablevscroll" : 1,
+						"devicewidth" : 0.0,
+						"description" : "",
+						"digest" : "",
+						"tags" : "",
+						"style" : "",
+						"subpatcher_template" : "",
+						"assistshowspatchername" : 0,
+						"boxes" : [ 							{
+								"box" : 								{
+									"id" : "obj-6",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 15.0, 102.0, 33.0, 22.0 ],
+									"text" : "Zero"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-4",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 15.0, 181.0, 152.0, 22.0 ],
+									"text" : "Zero"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-7",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 15.0, 42.0, 226.0, 20.0 ],
+									"text" : "This model is embedded in a bpatcher. ",
+									"textcolor" : [ 0.32549, 0.345098, 0.372549, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"fontsize" : 18.0,
+									"id" : "obj-19",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 15.0, 9.0, 291.0, 27.0 ],
+									"text" : "A model named 'submodel'"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-2",
+									"linecount" : 2,
+									"maxclass" : "newobj",
+									"numinlets" : 1,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 15.0, 131.0, 603.0, 35.0 ],
+									"text" : "ossia.parameter string_param @default Zero @type string @range Zero Uno Dos Tres Cuatro Cinco Seis Siete @clip both"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-1",
+									"maxclass" : "newobj",
+									"numinlets" : 1,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 15.0, 74.0, 130.0, 22.0 ],
+									"text" : "ossia.model submodel"
+								}
+
+							}
+ ],
+						"lines" : [ 							{
+								"patchline" : 								{
+									"destination" : [ "obj-4", 1 ],
+									"source" : [ "obj-2", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-2", 0 ],
+									"source" : [ "obj-6", 0 ]
+								}
+
+							}
+ ]
+					}
+,
+					"patching_rect" : [ 45.0, 331.234161376953125, 557.0, 218.765838623046875 ],
+					"viewvisibility" : 1
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-1",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 65.0, 77.0, 106.0, 22.0 ],
+					"text" : "ossia.device basic"
+				}
+
+			}
+ ],
+		"lines" : [ 			{
+				"patchline" : 				{
+					"destination" : [ "obj-11", 0 ],
+					"source" : [ "obj-10", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-44", 0 ],
+					"source" : [ "obj-11", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-7", 0 ],
+					"source" : [ "obj-11", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-44", 0 ],
+					"source" : [ "obj-12", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-19", 0 ],
+					"source" : [ "obj-14", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-3", 0 ],
+					"source" : [ "obj-19", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-10", 0 ],
+					"source" : [ "obj-2", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-11", 0 ],
+					"midpoints" : [ 343.5, 315.734161376953125, 266.5, 315.734161376953125, 266.5, 95.0, 303.5, 95.0 ],
+					"source" : [ "obj-44", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-44", 0 ],
+					"source" : [ "obj-5", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-12", 0 ],
+					"source" : [ "obj-6", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-14", 0 ],
+					"order" : 1,
+					"source" : [ "obj-7", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-17", 1 ],
+					"order" : 0,
+					"source" : [ "obj-7", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-8", 0 ],
+					"order" : 2,
+					"source" : [ "obj-7", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-11", 0 ],
+					"midpoints" : [ 329.5, 208.0, 278.5, 208.0, 278.5, 95.0, 303.5, 95.0 ],
+					"source" : [ "obj-8", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-44", 0 ],
+					"source" : [ "obj-8", 2 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-9", 0 ],
+					"source" : [ "obj-8", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-6", 0 ],
+					"source" : [ "obj-9", 0 ]
+				}
+
+			}
+ ],
+		"dependency_cache" : [ 			{
+				"name" : "ossia.device.mxo",
+				"type" : "iLaX"
+			}
+, 			{
+				"name" : "ossia.model.mxo",
+				"type" : "iLaX"
+			}
+, 			{
+				"name" : "ossia.parameter.mxo",
+				"type" : "iLaX"
+			}
+, 			{
+				"name" : "ossia.remote.mxo",
+				"type" : "iLaX"
+			}
+, 			{
+				"name" : "oscar.mxo",
+				"type" : "iLaX"
+			}
+ ],
+		"autosave" : 0,
+		"styles" : [ 			{
+				"name" : "Jamoma_highlighted_orange",
+				"default" : 				{
+					"accentcolor" : [ 1.0, 0.5, 0.0, 1.0 ]
+				}
+,
+				"parentstyle" : "",
+				"multi" : 0
+			}
+ ]
+	}
+
+}

--- a/src/ossia-max/src/utils.hpp
+++ b/src/ossia-max/src/utils.hpp
@@ -370,7 +370,7 @@ struct domain_visitor {
     {
       x->m_range_size = d.values.size() > OSSIA_MAX_MAX_ATTR_SIZE ? OSSIA_MAX_MAX_ATTR_SIZE : d.values.size();
       int i=0;
-      for(const auto& s : d.values.container)
+      for(const auto& s : d.values)
       {
         auto sym = gensym(s.c_str());
         A_SETSYM(x->m_range+i, sym);

--- a/src/ossia/network/domain/detail/domain_impl.cpp
+++ b/src/ossia/network/domain/detail/domain_impl.cpp
@@ -161,7 +161,7 @@ ossia::value numeric_clamp<Domain>::operator()(bounding_mode b, U&& val) const
   else
   {
     // Return a valid value only if it is in the given values
-    auto it = domain.values.find(val);
+    auto it = ossia::find(domain.values, val);
     if (it != domain.values.end())
     {
       return T(*it);
@@ -298,7 +298,7 @@ operator()(bounding_mode b, std::array<float, N> val) const
     for (std::size_t i = 0; i < N; i++)
     {
       // Return a valid value only if it is in the given values
-      auto it = values.find(val[i]);
+      auto it = ossia::find(values, val[i]);
       if (it == values.end())
       {
         return {};
@@ -737,7 +737,7 @@ value generic_clamp::operator()(bounding_mode b, const value& v) const
   else
   {
     // Return a valid value only if it is in the given values
-    auto it = values.find(v);
+    auto it = ossia::find(values, v);
     return (it != values.end()) ? v : ossia::value{};
   }
 }
@@ -802,7 +802,7 @@ value generic_clamp::operator()(bounding_mode b, value&& v) const
   else
   {
     // Return a valid value only if it is in the given values
-    auto it = values.find(v);
+    auto it = ossia::find(values, v);
     return (it != values.end()) ? std::move(v) : ossia::value{};
   }
 }
@@ -903,7 +903,7 @@ operator()(bounding_mode b, const std::vector<ossia::value>& val) const
     for (auto& v : val)
     {
       // Return a valid value only if all the subvalues are in the given values
-      auto it = values.find(v);
+      auto it = ossia::find(values, v);
       if (it == values.end())
       {
         return {};
@@ -998,7 +998,7 @@ operator()(bounding_mode b, std::vector<ossia::value>&& val) const
     for (auto& v : val)
     {
       // Return a valid value only if it is in the given values
-      auto it = values.find(v);
+      auto it = ossia::find(values, v);
       if (it == values.end())
       {
         // TODO should we remove the "bad" value instead ?

--- a/src/ossia/network/domain/detail/min_max.hpp
+++ b/src/ossia/network/domain/detail/min_max.hpp
@@ -674,7 +674,7 @@ struct domain_value_set_creation_visitor
     for (auto& value : values)
     {
       if (auto r = value.target<T>())
-        dom.values.insert(*r);
+        dom.values.push_back(*r);
     }
     return dom;
   }

--- a/src/ossia/network/domain/detail/value_set_domain.hpp
+++ b/src/ossia/network/domain/detail/value_set_domain.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <ossia/network/domain/domain_base.hpp>
+#include <ossia/detail/algorithms.hpp>
 
 namespace ossia
 {
@@ -21,7 +22,7 @@ struct value_set_clamp
     }
     else
     {
-      auto it = values.find(val);
+      auto it = ossia::find(values, val);
       return (it != values.end()) ? ossia::value{std::forward<U>(val)}
                                   : ossia::value{};
     }
@@ -78,10 +79,11 @@ struct value_set_update_visitor
   void operator()(ossia::domain_base<T>& dom)
   {
     dom.values.clear();
+    dom.values.reserve(values.size());
     for (auto& value : values)
     {
       if (auto r = value.target<T>())
-        dom.values.insert(*r);
+        dom.values.push_back(*r);
     }
   }
 
@@ -102,7 +104,7 @@ struct value_set_update_visitor
     dom.values.clear();
     for (auto& value : values)
     {
-      dom.values.insert(value);
+      dom.values.push_back(value);
     }
   }
 

--- a/src/ossia/network/domain/domain_base.cpp
+++ b/src/ossia/network/domain/domain_base.cpp
@@ -82,7 +82,7 @@ domain make_domain(const ossia::value& min, const ossia::value& max)
 domain make_domain(const std::vector<std::string>& s)
 {
   domain_base<std::string> v;
-  v.values.insert(s.begin(), s.end());
+  v.values.insert(v.values.end(), s.begin(), s.end());
   return domain{std::move(v)};
 }
 

--- a/src/ossia/network/domain/domain_base_impl.hpp
+++ b/src/ossia/network/domain/domain_base_impl.hpp
@@ -37,7 +37,7 @@ struct OSSIA_EXPORT domain_base
   using value_type = typename value_trait<T>::value_type;
   std::optional<value_type> min;
   std::optional<value_type> max;
-  ossia::flat_set<value_type> values;
+  std::vector<value_type> values;
 
   domain_base() noexcept
   {
@@ -132,7 +132,7 @@ struct OSSIA_EXPORT domain_base<bool>
 template <>
 struct OSSIA_EXPORT domain_base<std::string>
 {
-  ossia::flat_set<std::string> values;
+  std::vector<std::string> values;
   friend bool operator==(
       const domain_base<std::string>& lhs, const domain_base<std::string>& rhs)
   {
@@ -309,7 +309,7 @@ struct OSSIA_EXPORT domain_base<ossia::value>
   using value_type = ossia::value;
   std::optional<value_type> min;
   std::optional<value_type> max;
-  ossia::flat_set<value_type> values;
+  std::vector<value_type> values;
 
   domain_base() noexcept
   {
@@ -354,12 +354,12 @@ struct OSSIA_EXPORT domain_base<ossia::value>
   }
   domain_base(
       const value_type& v1, const value_type& v2,
-      const ossia::flat_set<value_type>& vals)
+      const std::vector<value_type>& vals)
       : min{v1}, max{v2}, values{vals}
   {
   }
   domain_base(
-      value_type&& v1, value_type&& v2, ossia::flat_set<value_type>&& vals)
+      value_type&& v1, value_type&& v2, std::vector<value_type>&& vals)
       : min{std::move(v1)}, max{std::move(v2)}, values{std::move(vals)}
   {
   }

--- a/src/ossia/network/domain/domain_conversion.hpp
+++ b/src/ossia/network/domain/domain_conversion.hpp
@@ -23,7 +23,7 @@ struct domain_conversion
       f.max = *t.max;
     if (!t.values.empty())
       for (auto val : t.values)
-        f.values.insert(val);
+        f.values.push_back(val);
     return f;
   }
 
@@ -36,7 +36,7 @@ struct domain_conversion
       f.max = *t.max;
     if (!t.values.empty())
       for (auto val : t.values)
-        f.values.insert(val);
+        f.values.push_back(val);
     return f;
   }
 
@@ -57,7 +57,7 @@ struct domain_conversion
       f.max = *t.max;
     if (!t.values.empty())
       for (auto val : t.values)
-        f.values.insert(val);
+        f.values.push_back(val);
     return f;
   }
 };

--- a/src/ossia/network/value/format_value.hpp
+++ b/src/ossia/network/value/format_value.hpp
@@ -133,6 +133,19 @@ struct formatter<std::vector<ossia::value>>
   }
 };
 
+template <typename T>
+struct formatter<std::vector<T>>
+{
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const std::vector<T>& v, FormatContext &ctx)
+  {
+    return format_vec(v, ctx);
+  }
+};
+
 template <>
 struct formatter<std::vector<fc::flat_set<std::vector<ossia::value>>>>
 {


### PR DESCRIPTION
use std::vector instead of ossia::flat_set to store range values
thus order is preserved
it's up to the user to use duplicate values and the behavior is not defined nor even tested

fix #565 