### PR TITLE
allow for output only osc_protocol

### DIFF
--- a/src/ossia/network/osc/osc.cpp
+++ b/src/ossia/network/osc/osc.cpp
@@ -94,6 +94,10 @@ void osc_protocol::update_sender()
 
 void osc_protocol::update_receiver()
 {
+  if (m_local_port == 0) {
+    m_receiver.reset();
+    return;
+  }
   m_receiver = std::make_unique<osc::receiver>(
       m_local_port, [this](const oscpack::ReceivedMessage& m,
                         const oscpack::IpEndpointName& ip) {
@@ -113,7 +117,7 @@ void osc_protocol::update_receiver()
 
 void osc_protocol::update_zeroconf()
 {
-  if (!m_expose)
+  if (!m_expose || m_local_port == 0)
     return;
   try
   {

--- a/src/ossia/network/osc/osc.cpp
+++ b/src/ossia/network/osc/osc.cpp
@@ -117,8 +117,10 @@ void osc_protocol::update_receiver()
 
 void osc_protocol::update_zeroconf()
 {
-  if (!m_expose || m_local_port == 0)
+  if (!m_expose || m_local_port == 0) {
+    m_zeroconfServer = {};
     return;
+  }
   try
   {
     m_zeroconfServer = net::make_zeroconf_server(

--- a/src/ossia/network/osc/osc.hpp
+++ b/src/ossia/network/osc/osc.hpp
@@ -29,7 +29,7 @@ class OSSIA_EXPORT osc_protocol final : public ossia::net::protocol_base
 {
 public:
   osc_protocol(
-      std::string ip, uint16_t remote_port, uint16_t local_port,
+      std::string ip, uint16_t remote_port, uint16_t local_port = 0,
       std::optional<std::string> expose_name = std::nullopt);
 
   osc_protocol(const osc_protocol&) = delete;


### PR DESCRIPTION
I'm using OSCQuery and adding UDP OSC output "listeners".
OSCQuery already provides a UDP endpoint so all I need is remote ports. This work enables that.