### PR TITLE
Xnor/async protocols osc multiplex test

### DIFF
--- a/src/ossia/protocols/osc/osc_generic_protocol.hpp
+++ b/src/ossia/protocols/osc/osc_generic_protocol.hpp
@@ -37,7 +37,7 @@ public:
 
   osc_generic_bidir_protocol(
       network_context_ptr ctx, const send_fd_configuration& send_conf, const receive_fd_configuration& recv_conf)
-      : can_learn<ossia::net::protocol_base>{flags{}}
+      : can_learn<ossia::net::protocol_base>{flags{SupportsMultiplex}}
       , m_ctx{std::move(ctx)}
       , m_id{*this}
       , from_client{recv_conf, m_ctx->context}
@@ -85,7 +85,7 @@ public:
 
   osc_generic_bidir_protocol(
       network_context_ptr ctx, const receive_socket_configuration& recv_conf)
-      : can_learn<ossia::net::protocol_base>{flags{}}
+      : can_learn<ossia::net::protocol_base>{flags{SupportsMultiplex}}
       , m_ctx{std::move(ctx)}
       , m_id{*this}
       , from_client{recv_conf, m_ctx->context}
@@ -102,7 +102,7 @@ public:
 
   osc_generic_bidir_protocol(
       network_context_ptr ctx, const send_fd_configuration& send_conf)
-      : can_learn<ossia::net::protocol_base>{flags{}}
+      : can_learn<ossia::net::protocol_base>{flags{SupportsMultiplex}}
       , m_ctx{std::move(ctx)}
       , m_id{*this}
       , to_client{send_conf, m_ctx->context}
@@ -112,7 +112,7 @@ public:
 
   osc_generic_bidir_protocol(
       network_context_ptr ctx, const receive_fd_configuration& recv_conf)
-      : can_learn<ossia::net::protocol_base>{flags{}}
+      : can_learn<ossia::net::protocol_base>{flags{SupportsMultiplex}}
       , m_ctx{std::move(ctx)}
       , m_id{*this}
       , from_client{recv_conf, m_ctx->context}
@@ -384,7 +384,7 @@ public:
   template<typename Configuration>
   osc_generic_client_protocol(
       network_context_ptr ctx, const Configuration& conf)
-      : can_learn<ossia::net::protocol_base>{flags{}}
+      : can_learn<ossia::net::protocol_base>{flags{SupportsMultiplex}}
       , m_ctx{std::move(ctx)}
       , m_id{*this}
       , m_client{conf, m_ctx->context}

--- a/src/ossia/protocols/osc/osc_generic_protocol.hpp
+++ b/src/ossia/protocols/osc/osc_generic_protocol.hpp
@@ -56,7 +56,7 @@ public:
 
   osc_generic_bidir_protocol(
       network_context_ptr ctx, const send_socket_configuration& send_conf, const receive_socket_configuration& recv_conf)
-      : can_learn<ossia::net::protocol_base>{flags{}}
+      : can_learn<ossia::net::protocol_base>{flags{SupportsMultiplex}}
       , m_ctx{std::move(ctx)}
       , m_id{*this}
       , from_client{recv_conf, m_ctx->context}
@@ -75,7 +75,7 @@ public:
 
   osc_generic_bidir_protocol(
       network_context_ptr ctx, const send_socket_configuration& send_conf)
-      : can_learn<ossia::net::protocol_base>{flags{}}
+      : can_learn<ossia::net::protocol_base>{flags{SupportsMultiplex}}
       , m_ctx{std::move(ctx)}
       , m_id{*this}
       , to_client{send_conf, m_ctx->context}
@@ -273,7 +273,7 @@ public:
   template<typename Configuration>
   osc_generic_server_protocol(
       network_context_ptr ctx, const Configuration& conf)
-      : can_learn<ossia::net::protocol_base>{flags{}}
+      : can_learn<ossia::net::protocol_base>{flags{SupportsMultiplex}}
       , m_ctx{std::move(ctx)}
       , m_id{*this}
       , m_server{conf, m_ctx->context}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -140,6 +140,7 @@ if(OSSIA_PROTOCOL_OSCQUERY)
     ossia_add_test(OSCQueryTreeCallbackTest  "${CMAKE_CURRENT_SOURCE_DIR}/Network/OSCQueryTreeCallbackTest.cpp")
     ossia_add_test(OSCQueryValueCallbackTest "${CMAKE_CURRENT_SOURCE_DIR}/Network/OSCQueryValueCallbackTest.cpp")
   endif()
+  ossia_add_test(MultiplexTest            "${CMAKE_CURRENT_SOURCE_DIR}/Network/MultiplexTest.cpp")
 endif()
 
 if(OSSIA_PROTOCOL_MIDI)

--- a/tests/Network/MultiplexTest.cpp
+++ b/tests/Network/MultiplexTest.cpp
@@ -30,10 +30,12 @@ TEST_CASE ("test_oscquery_osc_out", "test_oscquery_osc_out")
   auto osc = ossia::net::make_osc_protocol(
       ctx,
       {
-        conf::HOST,
-        conf::OSC1_1,
-        conf::SIZE_PREFIX,
-        ossia::net::udp_configuration{{{"0.0.0.0", 9998}, {"127.0.0.1", shared}}}
+        .mode = conf::HOST,
+        .version = conf::OSC1_1,
+        .transport = ossia::net::udp_configuration {{
+          .local = std::nullopt,
+          .remote = ossia::net::send_socket_configuration {{"127.0.0.1", shared}}
+        }}
       }
       );
   auto oscquery = std::make_unique<ossia::oscquery_asio::oscquery_server_protocol>(ctx);
@@ -49,10 +51,12 @@ TEST_CASE ("test_oscquery_osc_out", "test_oscquery_osc_out")
     ossia::net::make_osc_protocol(
         ctx,
         {
-          conf::MIRROR,
-          conf::OSC1_1,
-          conf::SIZE_PREFIX,
-          ossia::net::udp_configuration{{{"0.0.0.0", shared}, {"127.0.0.1", 9997}}}
+          .mode = conf::MIRROR,
+          .version = conf::OSC1_1,
+          .transport = ossia::net::udp_configuration {{
+            .local = ossia::net::receive_socket_configuration {{"0.0.0.0", shared}},
+            .remote = std::nullopt
+          }}
         }
         ),
       "test_osc"};

--- a/tests/Network/MultiplexTest.cpp
+++ b/tests/Network/MultiplexTest.cpp
@@ -1,0 +1,76 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check it.
+// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+#include <catch.hpp>
+
+#include <iostream>
+
+#include <ossia/context.hpp>
+#include <ossia/detail/config.hpp>
+#include <ossia/network/local/local.hpp>
+#include <ossia/network/oscquery/oscquery_server.hpp>
+
+#include "TestUtils.hpp"
+#include "ProtocolTestUtils.hpp"
+
+using namespace ossia;
+using namespace ossia::net;
+
+#if defined(OSSIA_PROTOCOL_OSC)
+#include <ossia/network/osc/osc.hpp>
+TEST_CASE ("test_oscquery_osc_out", "test_oscquery_osc_out")
+{
+  auto shared = 9996;
+  generic_device device{
+    std::make_unique<ossia::net::multiplex_protocol>(
+                std::make_unique<ossia::oscquery::oscquery_server_protocol>(),
+                std::make_unique<ossia::net::osc_protocol>("127.0.0.1", shared, 0)), //send only
+    "my_device"};
+  device.set_echo(true);
+
+  ossia::net::generic_device remote{
+    std::make_unique<ossia::net::osc_protocol>("127.0.0.1", 9997, shared), "test_osc"};
+
+  std::string address; 
+  ossia::value recv; 
+  auto on_server_message = [&] (const std::string& s, const ossia::value& v) {
+    address = s;
+    recv = v;
+  };
+  remote.on_unhandled_message.connect<decltype(on_server_message)>(on_server_message);
+
+  //test BI
+  auto& bi = find_or_create_node(device, "/foo/bi");
+  auto bip = bi.create_parameter(ossia::val_type::INT);
+  bi.set(access_mode_attribute{}, access_mode::BI);
+  bip->push_value(2084);
+
+  std::this_thread::sleep_for(std::chrono::microseconds(1000));
+  REQUIRE(address == "/foo/bi");
+  REQUIRE(recv == ossia::value { 2084 });
+
+  //test GET
+  address = std::string();
+  auto& get = find_or_create_node(device, "/foo/get");
+  auto getp = get.create_parameter(ossia::val_type::INT);
+  get.set(access_mode_attribute{}, access_mode::GET);
+  getp->push_value(42);
+
+  std::this_thread::sleep_for(std::chrono::microseconds(1000));
+  REQUIRE(address == "/foo/get");
+  REQUIRE(recv == ossia::value { 42 });
+
+  //test SET
+  address = std::string();
+  auto& set = find_or_create_node(device, "/foo/set");
+  auto setp = set.create_parameter(ossia::val_type::INT);
+  set.set(access_mode_attribute{}, access_mode::SET);
+  setp->push_value(1000);
+
+  //shouldn't get anything in the remote
+  std::this_thread::sleep_for(std::chrono::microseconds(1000));
+  REQUIRE(address.size() == 0);
+  REQUIRE(recv == ossia::value { 42 }); //stays the same
+
+}
+#endif


### PR DESCRIPTION
one test fails SET values are still send out, though I know that OSCQuery displays SET values so maybe this is just expected behavior, feels especially wrong in plain OSC though.

Not sure if all of these protocols should support multiplex or not..

the other test fails with a crash when a large OSC message is echoed from OSCQuery to UDP OSC.