### PR TITLE
add mpark/variant as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,9 @@
 [submodule "3rdparty/variant"]
     path = 3rdparty/variant
     url = https://github.com/eggs-cpp/variant
+[submodule "3rdparty/mparkvariant"]
+	path = 3rdparty/mparkvariant
+	url = https://github.com/mpark/variant
 [submodule "3rdparty/oscpack"]
     path = 3rdparty/oscpack
     url = https://github.com/jcelerier/oscpack


### PR DESCRIPTION
as we intend to use this instead of `std::variant` for future developments.

I am not sure if there are already little internal things, that could benefit from leveraging it in this repository, nor if there are additional changes needed here.

Intent is to use it from score-midi-plugin and maybe other places.