### PR TITLE
multiplex thread safe

### DIFF
--- a/src/ossia/network/local/local.cpp
+++ b/src/ossia/network/local/local.cpp
@@ -41,6 +41,7 @@ bool multiplex_protocol::pull(ossia::net::parameter_base& address)
 bool multiplex_protocol::push(const ossia::net::parameter_base& address, const ossia::value& v)
 {
   bool b = true;
+  std::lock_guard<std::mutex> guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     b &= proto->push(address, v);
 
@@ -50,6 +51,7 @@ bool multiplex_protocol::push(const ossia::net::parameter_base& address, const o
 bool multiplex_protocol::push_raw(const full_parameter_data& dat)
 {
   bool b = true;
+  std::lock_guard<std::mutex> guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     b &= proto->push_raw(dat);
 
@@ -60,6 +62,7 @@ bool multiplex_protocol::observe(
     ossia::net::parameter_base& address, bool enable)
 {
   bool b = true;
+  std::lock_guard<std::mutex> guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     b &= proto->observe_quietly(address, enable);
 
@@ -74,6 +77,7 @@ bool multiplex_protocol::update(ossia::net::node_base& node)
 bool multiplex_protocol::echo_incoming_message(const message_origin_identifier& id, const parameter_base& param, const value& v)
 {
   bool b = true;
+  std::lock_guard<std::mutex> guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     b &= proto->echo_incoming_message(id, param, v);
   return b;
@@ -81,6 +85,7 @@ bool multiplex_protocol::echo_incoming_message(const message_origin_identifier& 
 
 void multiplex_protocol::stop()
 {
+  std::lock_guard<std::mutex> guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     proto->stop();
 }
@@ -88,6 +93,7 @@ void multiplex_protocol::stop()
 void multiplex_protocol::set_device(device_base& dev)
 {
   m_device = &dev;
+  std::lock_guard<std::mutex> guard(m_protocols_mutex);
   for(auto& p : m_protocols_to_register)
   {
     p->set_device(*m_device);
@@ -111,6 +117,7 @@ void multiplex_protocol::expose_to(std::unique_ptr<protocol_base> p)
        return;
     }
 
+    std::lock_guard<std::mutex> guard(m_protocols_mutex);
     if(m_device)
     {
       p->set_device(*m_device);
@@ -129,12 +136,14 @@ void multiplex_protocol::expose_to(std::unique_ptr<protocol_base> p)
 
 void multiplex_protocol::stop_expose_to(const protocol_base& p)
 {
+  std::lock_guard<std::mutex> guard(m_protocols_mutex);
   ossia::remove_erase_if(m_protocols_to_register, [&](const auto& ptr) { return ptr.get() == &p; });
   ossia::remove_erase_if(m_protocols, [&](const auto& ptr) { return ptr.get() == &p; });
 }
 
 void ossia::net::multiplex_protocol::clear()
 {
+  std::lock_guard<std::mutex> guard(m_protocols_mutex);
   m_protocols.clear();
 }
 }

--- a/src/ossia/network/local/local.cpp
+++ b/src/ossia/network/local/local.cpp
@@ -6,6 +6,8 @@
 
 #include <ossia/detail/logger.hpp>
 
+using lock_guard = std::lock_guard<ossia::audio_spin_mutex>;
+
 namespace ossia::net
 {
 static void observe_rec(protocol_base& proto, ossia::net::node_base& n)
@@ -41,7 +43,7 @@ bool multiplex_protocol::pull(ossia::net::parameter_base& address)
 bool multiplex_protocol::push(const ossia::net::parameter_base& address, const ossia::value& v)
 {
   bool b = true;
-  std::lock_guard<std::mutex> guard(m_protocols_mutex);
+  lock_guard guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     b &= proto->push(address, v);
 
@@ -51,7 +53,7 @@ bool multiplex_protocol::push(const ossia::net::parameter_base& address, const o
 bool multiplex_protocol::push_raw(const full_parameter_data& dat)
 {
   bool b = true;
-  std::lock_guard<std::mutex> guard(m_protocols_mutex);
+  lock_guard guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     b &= proto->push_raw(dat);
 
@@ -62,7 +64,7 @@ bool multiplex_protocol::observe(
     ossia::net::parameter_base& address, bool enable)
 {
   bool b = true;
-  std::lock_guard<std::mutex> guard(m_protocols_mutex);
+  lock_guard guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     b &= proto->observe_quietly(address, enable);
 
@@ -77,7 +79,7 @@ bool multiplex_protocol::update(ossia::net::node_base& node)
 bool multiplex_protocol::echo_incoming_message(const message_origin_identifier& id, const parameter_base& param, const value& v)
 {
   bool b = true;
-  std::lock_guard<std::mutex> guard(m_protocols_mutex);
+  lock_guard guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     b &= proto->echo_incoming_message(id, param, v);
   return b;
@@ -85,7 +87,7 @@ bool multiplex_protocol::echo_incoming_message(const message_origin_identifier& 
 
 void multiplex_protocol::stop()
 {
-  std::lock_guard<std::mutex> guard(m_protocols_mutex);
+  lock_guard guard(m_protocols_mutex);
   for (auto& proto : m_protocols)
     proto->stop();
 }
@@ -93,7 +95,7 @@ void multiplex_protocol::stop()
 void multiplex_protocol::set_device(device_base& dev)
 {
   m_device = &dev;
-  std::lock_guard<std::mutex> guard(m_protocols_mutex);
+  lock_guard guard(m_protocols_mutex);
   for(auto& p : m_protocols_to_register)
   {
     p->set_device(*m_device);
@@ -117,7 +119,7 @@ void multiplex_protocol::expose_to(std::unique_ptr<protocol_base> p)
        return;
     }
 
-    std::lock_guard<std::mutex> guard(m_protocols_mutex);
+    lock_guard guard(m_protocols_mutex);
     if(m_device)
     {
       p->set_device(*m_device);
@@ -136,14 +138,14 @@ void multiplex_protocol::expose_to(std::unique_ptr<protocol_base> p)
 
 void multiplex_protocol::stop_expose_to(const protocol_base& p)
 {
-  std::lock_guard<std::mutex> guard(m_protocols_mutex);
+  lock_guard guard(m_protocols_mutex);
   ossia::remove_erase_if(m_protocols_to_register, [&](const auto& ptr) { return ptr.get() == &p; });
   ossia::remove_erase_if(m_protocols, [&](const auto& ptr) { return ptr.get() == &p; });
 }
 
 void ossia::net::multiplex_protocol::clear()
 {
-  std::lock_guard<std::mutex> guard(m_protocols_mutex);
+  lock_guard guard(m_protocols_mutex);
   m_protocols.clear();
 }
 }

--- a/src/ossia/network/local/local.hpp
+++ b/src/ossia/network/local/local.hpp
@@ -2,6 +2,7 @@
 
 #include <ossia/detail/algorithms.hpp>
 #include <ossia/network/base/protocol.hpp>
+#include <ossia/detail/audio_spin_mutex.hpp>
 
 #include <vector>
 
@@ -64,7 +65,7 @@ public:
 
 private:
   std::vector<std::unique_ptr<ossia::net::protocol_base>> m_protocols;
-  std::mutex m_protocols_mutex;
+  ossia::audio_spin_mutex m_protocols_mutex;
   std::vector<std::unique_ptr<ossia::net::protocol_base>> m_protocols_to_register;
   ossia::net::device_base* m_device{};
 };

--- a/src/ossia/network/local/local.hpp
+++ b/src/ossia/network/local/local.hpp
@@ -64,6 +64,7 @@ public:
 
 private:
   std::vector<std::unique_ptr<ossia::net::protocol_base>> m_protocols;
+  std::mutex m_protocols_mutex;
   std::vector<std::unique_ptr<ossia::net::protocol_base>> m_protocols_to_register;
   ossia::net::device_base* m_device{};
 };


### PR DESCRIPTION
the protocol iteration wasn't thread safe.. so one thread could remove a protocol and another could be pushing to them..
this now means that pushing values might not be realtime safe, but in practice if you're only updating from a single thread, the mutexes should just be quick spinlocks?

I'm open to suggestions for changes in this though