### PR TITLE
Fix typos in src/ subdir

### DIFF
--- a/src/ossia-c/ossia-c.h
+++ b/src/ossia-c/ossia-c.h
@@ -9,7 +9,7 @@
  *
  * The API can be used to declare or interact with a tree of parameters.
  *
- * There are mutiple namespaces :
+ * There are multiple namespaces :
  *
  * * The `ossia_protocol_*` functions allow interoperation with protocols supported by
  * libossia.
@@ -284,7 +284,7 @@ const char* ossia_device_get_name(ossia_device_t device);
  *
  * @see ossia::net::device_base::on_node_created
  * @note Multithread guarantees: MT-Safe.
- *       The callback is called from the thread where the modification occured.
+ *       The callback is called from the thread where the modification occurred.
  */
 OSSIA_EXPORT
 ossia_node_callback_idx_t ossia_device_add_node_created_callback(
@@ -312,7 +312,7 @@ void ossia_device_remove_node_created_callback(
  *
  * @see ossia::net::device_base::on_node_removing
  * @note Multithread guarantees: MT-Safe.
- *       The callback is called from the thread where the modification occured.
+ *       The callback is called from the thread where the modification occurred.
  */
 OSSIA_EXPORT
 ossia_node_callback_idx_t ossia_device_add_node_removing_callback(
@@ -339,7 +339,7 @@ void ossia_device_remove_node_removing_callback(
  *
  * @see ossia::net::device_base::on_parameter_removing
  * @note Multithread guarantees: MT-Safe.
- *       The callback is called from the thread where the modification occured.
+ *       The callback is called from the thread where the modification occurred.
  */
 OSSIA_EXPORT
 ossia_parameter_callback_idx_t ossia_device_add_parameter_deleting_callback(

--- a/src/ossia-cpp/ossia-cpp98.hpp
+++ b/src/ossia-cpp/ossia-cpp98.hpp
@@ -513,7 +513,7 @@ typedef void (*attribute_modified_callback)(void*, const opp::node&, const std::
  */
 typedef bool (*rename_node_callback)(void*, const std::string&, const std::string&);
 /** @brief container for a node remove request callback
- * sould return true if node could be remove
+ * should return true if node could be remove
  */
 typedef bool (*remove_node_callback)(void*, const std::string&);
 /** @brief container for a node creation request callback
@@ -858,7 +858,7 @@ public:
    */
   void set_decibel();
   /**
-   * midigain: a value in the [0 127] range mimicing a MIDI gain controller. 100 for the
+   * midigain: a value in the [0 127] range mimicking a MIDI gain controller. 100 for the
    * nominal level, 127 for +12dB
    * @brief adds a float parameter to the current node, with the gain.midigain unit
    */
@@ -1142,7 +1142,7 @@ public:
    */
   node create_decibel(std::string addr);
   /**
-   * midigain: a value in the [0 127] range mimicing a MIDI gain controller. 100 for the
+   * midigain: a value in the [0 127] range mimicking a MIDI gain controller. 100 for the
    * nominal level, 127 for +12dB
    * @brief creates a child node with tne given name,
    * and a float parameter with the gain.midigain unit in the [0 127) range
@@ -1463,7 +1463,7 @@ public:
    *   + **linear**:
    * A linear gain in the [0. 1.] range, with 1. being the nominal level
    *   + **midigain**:
-   * A value in the [0 127] range mimicing a MIDI gain controller. 100 for the nominal
+   * A value in the [0 127] range mimicking a MIDI gain controller. 100 for the nominal
    * level, 127 for +12dB
    *   + **decibel** (*db*, *dB*):
    * A single float value expressed in a logarithmic scale, typically to describe an
@@ -1664,7 +1664,7 @@ public:
   node& unset_instance_bounds();
   /**
    * @brief gets how many instances this node can have
-   * @return a std::pair with the minimum and maxium number sof instances this node can
+   * @return a std::pair with the minimum and maximum number of instances this node can
    * have
    */
   std::pair<int, int> get_instance_bounds() const;

--- a/src/ossia-max/docs/refpages/ossia.attribute.maxref.xml
+++ b/src/ossia-max/docs/refpages/ossia.attribute.maxref.xml
@@ -33,8 +33,8 @@
 	<!--OUTLETS-->
 	<outletlist>
 		<outlet id="0" name="Value output" type="any">
-			<digest>Parameter attrbute value</digest>
-			<description>Parameter attrbute value</description>
+			<digest>Parameter attribute value</digest>
+			<description>Parameter attribute value</description>
 		</outlet>
 	</outletlist>
 	
@@ -161,7 +161,7 @@
 
 		<attribute name="description" get="1" set="1" type="atom" size="1">
 			<digest>
-				Descrption of bound parameter 
+				Description of bound parameter 
 			</digest>
 			<description>
 				The <at>description</at> attribute allows to give the bound parameter a textual description. This helps documenting the parameter.

--- a/src/ossia-max/docs/refpages/ossia.client.maxref.xml
+++ b/src/ossia-max/docs/refpages/ossia.client.maxref.xml
@@ -8,7 +8,7 @@
 	</digest>
 
 	<description>
-		<o>ossia.client</o> allows to connect to a distant device (either locally or on another computer) through various protcols, and lets you bind to it through <o>ossia.view</o> and <o>ossia.remote</o>
+		<o>ossia.client</o> allows to connect to a distant device (either locally or on another computer) through various protocols, and lets you bind to it through <o>ossia.view</o> and <o>ossia.remote</o>
 	</description>
 
 	
@@ -119,7 +119,7 @@
 
 		<attribute name="description" get="1" set="1" type="atom" size="1">
 			<digest>
-				Descirption of this node
+				Description of this node
 			</digest>
 			<description>
 				The <at>description</at> attribute allows to give a textual description for this node. This helps documenting the parameter.

--- a/src/ossia-max/docs/refpages/ossia.device.maxref.xml
+++ b/src/ossia-max/docs/refpages/ossia.device.maxref.xml
@@ -120,7 +120,7 @@
 
 		<attribute name="description" get="1" set="1" type="atom" size="1">
 			<digest>
-				Descirption of this node
+				Description of this node
 			</digest>
 			<description>
 				The <at>description</at> attribute allows to give a textual description for this node. This helps documenting the parameter.

--- a/src/ossia-max/docs/refpages/ossia.maxref.xml
+++ b/src/ossia-max/docs/refpages/ossia.maxref.xml
@@ -78,7 +78,7 @@ all parameters and models will be registered (until an [ossia.device object is a
 
 		<attribute name="description" get="1" set="1" type="atom" size="1">
 			<digest>
-				Descirption of this node
+				Description of this node
 			</digest>
 			<description>
 				The <at>description</at> attribute allows to give a textual description for this node. This helps documenting the parameter.

--- a/src/ossia-max/docs/refpages/ossia.parameter.maxref.xml
+++ b/src/ossia-max/docs/refpages/ossia.parameter.maxref.xml
@@ -211,7 +211,7 @@
 
 		<attribute name="description" get="1" set="1" type="atom" size="1">
 			<digest>
-				Descrption of this node
+				Description of this node
 			</digest>
 			<description>
 				The <at>description</at> attribute allows to agive a textual description for this node. This helps documenting the parameter.

--- a/src/ossia-max/docs/refpages/ossia.remote.maxref.xml
+++ b/src/ossia-max/docs/refpages/ossia.remote.maxref.xml
@@ -222,7 +222,7 @@
 		
 		<attribute name="description" get="1" set="1" type="atom" size="1">
 			<digest>
-				Descrption of this node
+				Description of this node
 			</digest>
 			<description>
 				The <at>description</at> attribute allows to agive a textual description for this node. This helps documenting the parameter.

--- a/src/ossia-max/help/ossia.device.maxhelp
+++ b/src/ossia-max/help/ossia.device.maxhelp
@@ -508,7 +508,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 608.5, 473.0, 266.0, 79.0 ],
-									"text" : "Parameters in a device can be remotely bound to using 'device_name:/model/parameter' absolute address syntaxe",
+									"text" : "Parameters in a device can be remotely bound to using 'device_name:/model/parameter' absolute address syntax",
 									"textcolor" : [ 0.3, 0.3, 0.3, 1.0 ]
 								}
 

--- a/src/ossia-max/help/ossia.logger.maxhelp
+++ b/src/ossia-max/help/ossia.logger.maxhelp
@@ -172,7 +172,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 406.5, 289.5, 163.0, 22.0 ],
-					"text" : "warning My warnin message"
+					"text" : "warning My warning message"
 				}
 
 			}

--- a/src/ossia-max/help/ossia.maxhelp
+++ b/src/ossia-max/help/ossia.maxhelp
@@ -1389,7 +1389,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 142.0, 365.5, 369.0, 35.0 ],
-					"text" : "Get the namespace (all adresses registered to the global device)",
+					"text" : "Get the namespace (all addresses registered to the global device)",
 					"textcolor" : [ 0.3, 0.3, 0.3, 1.0 ]
 				}
 

--- a/src/ossia-max/help/ossia.parameter.maxhelp
+++ b/src/ossia-max/help/ossia.parameter.maxhelp
@@ -613,7 +613,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 137.0, 441.5, 174.0, 35.0 ],
-									"text" : "See syntaxe details",
+									"text" : "See syntax details",
 									"textcolor" : [ 0.3, 0.3, 0.3, 1.0 ]
 								}
 
@@ -716,7 +716,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 0,
 													"patching_rect" : [ 17.0, 11.0, 502.0, 194.0 ],
-													"text" : "Syntax is:\n* will match everything until the next slash\n! will match all instances of a node, including the original (e.g. /foo, /foo.1 and /foo.A)\n{1..12} wil match instances for all numbers between 1 and 12 \n{A|b|some|things} will match all strings between pipes or commas - avoid spaces\n\n? will match any character (but just one)\n[a-u] will match  each character between  a and u\n[abu] will match a, b and u\n[1-5] this works also for numbers, but only one digit at a time (use braces for higher numbers)\n\n// will match across disparate branches of the address tree and at any depth \n(e.g. //bar will match: /foo/bar, /bar, /foo/sub/level/bar) ",
+													"text" : "Syntax is:\n* will match everything until the next slash\n! will match all instances of a node, including the original (e.g. /foo, /foo.1 and /foo.A)\n{1..12} will match instances for all numbers between 1 and 12 \n{A|b|some|things} will match all strings between pipes or commas - avoid spaces\n\n? will match any character (but just one)\n[a-u] will match  each character between  a and u\n[abu] will match a, b and u\n[1-5] this works also for numbers, but only one digit at a time (use braces for higher numbers)\n\n// will match across disparate branches of the address tree and at any depth \n(e.g. //bar will match: /foo/bar, /bar, /foo/sub/level/bar) ",
 													"textcolor" : [ 0.6, 0.6, 0.6, 1.0 ]
 												}
 
@@ -746,7 +746,7 @@
 										"tags" : ""
 									}
 ,
-									"text" : "p Syntaxe details"
+									"text" : "p Syntax details"
 								}
 
 							}
@@ -773,7 +773,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 28.0, 297.0, 647.5, 136.0 ],
-									"text" : "Syntax is:\n{some|words|or|others} wil create one instance per word between the '|' (pipe)\n{1..12} wil create instances for all numbers between 1 and 12 \n{3..13..3} will create instances for all numbers between 3 and 13, with a step of 3 (i.e. 3, 6, 9, 12 \n{A,b,some,things} will create an instance for each string between commas (avoid spaces)\n\n[a-u] will create one of each character between  a and u\n[abc] will create one of each character (a, b and c)\n[1-5] this works also for numbers (one digit at a time, see above for numbers above 10)",
+									"text" : "Syntax is:\n{some|words|or|others} will create one instance per word between the '|' (pipe)\n{1..12} will create instances for all numbers between 1 and 12 \n{3..13..3} will create instances for all numbers between 3 and 13, with a step of 3 (i.e. 3, 6, 9, 12 \n{A,b,some,things} will create an instance for each string between commas (avoid spaces)\n\n[a-u] will create one of each character between  a and u\n[abc] will create one of each character (a, b and c)\n[1-5] this works also for numbers (one digit at a time, see above for numbers above 10)",
 									"textcolor" : [ 0.6, 0.6, 0.6, 1.0 ]
 								}
 

--- a/src/ossia-max/help/ossia.remote.maxhelp
+++ b/src/ossia-max/help/ossia.remote.maxhelp
@@ -723,7 +723,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 709.0, 669.5, 174.0, 35.0 ],
-									"text" : "See syntaxe details",
+									"text" : "See syntax details",
 									"textcolor" : [ 0.3, 0.3, 0.3, 1.0 ]
 								}
 
@@ -826,7 +826,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 0,
 													"patching_rect" : [ 17.0, 11.0, 502.0, 194.0 ],
-													"text" : "Syntax is:\n* will match everything until the next slash\n! will match all instances of a node, including the original (e.g. /foo, /foo.1 and /foo.A)\n{1..12} wil match instances for all numbers between 1 and 12 \n{A|b|some|things} will match all strings between pipes or commas - avoid spaces\n\n? will match any character (but just one)\n[a-u] will match  each character between  a and u\n[abu] will match a, b and u\n[1-5] this works also for numbers, but only one digit at a time (use braces for higher numbers)\n\n// will match across disparate branches of the address tree and at any depth \n(e.g. //bar will match: /foo/bar, /bar, /foo/sub/level/bar) ",
+													"text" : "Syntax is:\n* will match everything until the next slash\n! will match all instances of a node, including the original (e.g. /foo, /foo.1 and /foo.A)\n{1..12} will match instances for all numbers between 1 and 12 \n{A|b|some|things} will match all strings between pipes or commas - avoid spaces\n\n? will match any character (but just one)\n[a-u] will match  each character between  a and u\n[abu] will match a, b and u\n[1-5] this works also for numbers, but only one digit at a time (use braces for higher numbers)\n\n// will match across disparate branches of the address tree and at any depth \n(e.g. //bar will match: /foo/bar, /bar, /foo/sub/level/bar) ",
 													"textcolor" : [ 0.6, 0.6, 0.6, 1.0 ]
 												}
 
@@ -856,7 +856,7 @@
 										"tags" : ""
 									}
 ,
-									"text" : "p Syntaxe details"
+									"text" : "p Syntax details"
 								}
 
 							}
@@ -952,7 +952,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 58.0, 560.0, 231.0, 35.0 ],
-									"text" : "you can also access a row of parameteres \nwith a list thanks to ossia.remote_array",
+									"text" : "you can also access a row of parameters \nwith a list thanks to ossia.remote_array",
 									"textcolor" : [ 0.6, 0.6, 0.6, 1.0 ]
 								}
 
@@ -2824,7 +2824,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 55.5, 269.5, 211.5, 64.0 ],
-									"text" : "1st outlet is deffered (useful  for UI that do not need high refresh rate)",
+									"text" : "1st outlet is deferred (useful  for UI that do not need high refresh rate)",
 									"textcolor" : [ 0.3, 0.3, 0.3, 1.0 ]
 								}
 

--- a/src/ossia-max/max-test/615-hangs.maxpat
+++ b/src/ossia-max/max-test/615-hangs.maxpat
@@ -158,7 +158,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 184.0, 217.5, 160.0, 24.0 ],
-					"text" : "workaroud for issue #588"
+					"text" : "workaround for issue #588"
 				}
 
 			}

--- a/src/ossia-max/max-test/616-outpu_address_with_pattern_matching.maxpat
+++ b/src/ossia-max/max-test/616-outpu_address_with_pattern_matching.maxpat
@@ -136,7 +136,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 280.0, 380.0, 214.0, 24.0 ],
-					"text" : "2.communicate with frequncy = fine"
+					"text" : "2.communicate with frequency = fine"
 				}
 
 			}

--- a/src/ossia-max/src/object_base.cpp
+++ b/src/ossia-max/src/object_base.cpp
@@ -216,7 +216,7 @@ std::vector<std::shared_ptr<matcher>> object_base::find_or_create_matchers()
         // For ossia.parameter:
         //    if we find a node, then we check if it already has a parameter.
         //        If no, create a parameter
-        //        If yes, return a new node with incremeted suffix with a parameter
+        //        If yes, return a new node with incremented suffix with a parameter
         //    else we create a new node and a parameter
         // For ossia.model: if we found a node, duplicate it, otherwise create it.
         // For others: if we found a node, return it.
@@ -373,7 +373,7 @@ void object_base::loadbang(object_base* x)
   else
   {
     // if patcher has not been loadbanged, register all objects in that patcher
-    // this happens when the patcher is loaded or instanciated as an abstraction
+    // this happens when the patcher is loaded or instantiated as an abstraction
     // and also when it is pasted / duplicated
     register_children_in_patcher_recursively(root_patcher, nullptr);
     output_all_values(root_patcher, true);

--- a/src/ossia-max/src/object_base.hpp
+++ b/src/ossia-max/src/object_base.hpp
@@ -72,7 +72,7 @@ public:
   void* m_dumpout{};
 
   // flags
-  bool m_dead{false}; // wether this object is being deleted or not;
+  bool m_dead{false}; // whether this object is being deleted or not;
   bool m_is_deleted{};
   bool m_lock{false}; // attribute lock
   bool m_local_mute{false};

--- a/src/ossia-max/src/ossia-max.cpp
+++ b/src/ossia-max/src/ossia-max.cpp
@@ -365,7 +365,7 @@ std::vector<object_base*> find_children_to_register(
         if(current == subclassname || (!found_view && current == gensym("ossia.remote")))
         {
 
-          // the object itself shouln't be stored
+          // the object itself shouldn't be stored
           if(object_box != next_box)
           {
             object_base* o = (object_base*)jbox_get_object(next_box);

--- a/src/ossia-max/src/parameter_base.cpp
+++ b/src/ossia-max/src/parameter_base.cpp
@@ -1139,7 +1139,7 @@ void parameter_base::class_setup(t_class* c)
 
   CLASS_ATTR_SYM(c, "mode", 0, parameter_base, m_access_mode);
   CLASS_ATTR_ENUM(c, "mode", 0, "bi get set");
-  CLASS_ATTR_LABEL(c, "mode", 0, "Acces Mode");
+  CLASS_ATTR_LABEL(c, "mode", 0, "Access Mode");
 
   CLASS_ATTR_ATOM_VARSIZE(
       c, "default", 0, parameter_base, m_default, m_default_size,

--- a/src/ossia-max/src/utils.hpp
+++ b/src/ossia-max/src/utils.hpp
@@ -96,7 +96,7 @@ ossia::val_type symbol2val_type(t_symbol* s);
 t_symbol* val_type2symbol(ossia::val_type t);
 
 /**
- * @brief symbol2bounding_mode convert t_symbol* to corresponging ossia::bounding_mode
+ * @brief symbol2bounding_mode convert t_symbol* to corresponding ossia::bounding_mode
  * @param t_symbol* bounding_mode
  * @return ossia::bounding_mode
  */

--- a/src/ossia-max/unit-test/README.md
+++ b/src/ossia-max/unit-test/README.md
@@ -1,7 +1,7 @@
 ossia-max unit tests
 ====================
 
-This folder contains a `logger-server.js` that loads sequencially each patcher which name ends with ".ossia-max-test.maxpat".
+This folder contains a `logger-server.js` that loads sequentially each patcher which name ends with ".ossia-max-test.maxpat".
 Those patchers should contains one or more `ossia.assert` objects and a `ossia.test-logger` object.
 
 Please disable the "Restore Windows on Launch" Max's option to prevent Max from reloading other patchers then the one we want to test.

--- a/src/ossia-max/watchdog/watch_help_modifications.sh
+++ b/src/ossia-max/watchdog/watch_help_modifications.sh
@@ -10,7 +10,7 @@ DESTINATION_FOLDER=${REPO_ROOT}/help
 echo "watch $SOURCE_FOLDER and target $DESTINATION_FOLDER"
 
 if [[ ! -e $SOURCE_FOLDER ]]; then
-	echo "Souce folder $SOURCE_FOLDER doesn't exist"
+	echo "Source folder $SOURCE_FOLDER doesn't exist"
 	echo "Usage: ${0} <build folder>"
 	exit 1
 fi

--- a/src/ossia-node/ossia-node.cpp
+++ b/src/ossia-node/ossia-node.cpp
@@ -112,7 +112,7 @@ public:
   {
   }
 
-  ~Node() { std::cerr << "Node destoryed\n"; }
+  ~Node() { std::cerr << "Node destroyed\n"; }
 
   static NAN_METHOD(New)
   {
@@ -169,7 +169,7 @@ public:
   {
   }
 
-  ~Device() { std::cerr << "Device destoryed\n"; }
+  ~Device() { std::cerr << "Device destroyed\n"; }
 
   static NAN_METHOD(New)
   {

--- a/src/ossia-pd/examples/client-example.qml
+++ b/src/ossia-pd/examples/client-example.qml
@@ -9,7 +9,7 @@ import Ossia 1.0 as Ossia
  * provided by the qml-creative-controls library, with libossia and PureData.
  *
  * In the current example, the application we are writing acts as a client:
- * that is, it connects to existing adresses / parameters of a remote
+ * that is, it connects to existing addresses / parameters of a remote
  * software / hardware. It is meant to be used with device-example.pd patch.
  * Open the device-example.pd patch in PureData
  * then open this QML application with qmlscene for example.

--- a/src/ossia-pd/examples/device-example.pd
+++ b/src/ossia-pd/examples/device-example.pd
@@ -104,7 +104,7 @@ time" @tags envelope @default 10, f 51;
 #X connect 12 0 9 0;
 #X restore 25 79 pd randomtest;
 #X obj 392 550 loadbang;
-#X text 214 23 A simple synth to demonstrate communiation between Ossia
+#X text 214 23 A simple synth to demonstrate communication between Ossia
 device and client., f 42;
 #X floatatom 141 197 5 0 0 0 - - -, f 5;
 #X obj 145 576 loadbang;

--- a/src/ossia-pd/helps/ossia-help.pd
+++ b/src/ossia-pd/helps/ossia-help.pd
@@ -75,7 +75,7 @@ you used the default ports More queries are possible in this way \,
 e.g. http://localhost:5678/foo or http://localhost:5678/foo?VALUE,
 f 116;
 #X text 145 310 allows to get the namespace \, i.e. the list of the
-adresses registered to the global device., f 96;
+addresses registered to the global device., f 96;
 #X text 27 783 ________________________________________________________________________________________________________________
 , f 122;
 #X text 30 815 Please report bugs on: https://github.com/ossia/libossia/issues

--- a/src/ossia-pd/helps/ossia.model-help.pd
+++ b/src/ossia-pd/helps/ossia.model-help.pd
@@ -31,7 +31,7 @@
 #X connect 2 0 3 0;
 #X restore 121 215 pd print-namespace;
 #X text 36 38 This helps creating complex and nested address hierarchies
-(a.k.a. namespaces) to sort numerous parameters by functionnality.
+(a.k.a. namespaces) to sort numerous parameters by functionality.
 , f 94;
 #X text 36 18 [ø.model] creates a node under which several [ø.param]s
 (and models) can subscribe, f 94;

--- a/src/ossia-pd/helps/ossia.param-help.pd
+++ b/src/ossia-pd/helps/ossia.param-help.pd
@@ -7,9 +7,9 @@
 \, RGB color;
 #X text 668 207 vec4f : list of 4 float values \, useful for RGBA color
 ;
-#X text 653 649 @tags <symbol> string list to decribe some key features
+#X text 653 649 @tags <symbol> string list to describe some key features
 (like audio \, video \, synthesis \, effect...);
-#X text 653 678 @description <symbol> textual decription of the parameter
+#X text 653 678 @description <symbol> textual description of the parameter
 ;
 #X text 649 51 @type <symbol> define value type \, could be one of
 :;

--- a/src/ossia-pd/helps/ossia.remote-help.pd
+++ b/src/ossia-pd/helps/ossia.remote-help.pd
@@ -181,7 +181,7 @@ the models to see this in action, f 65;
 #X obj 145 80 ossia.remote /sub/bar;
 #X floatatom 108 81 5 0 0 0 - - -, f 5;
 #X text 33 29 when there are several levels of hierarchies \, one can
-use absolute addresses \, refering to the current device's root \,
+use absolute addresses \, referring to the current device's root \,
 and starting with a leading slash:;
 #X text 29 120 NB: There is no [ossia.device] here so all ossia objects
 refer to the default global device - see [ossia] for more on that,
@@ -225,7 +225,7 @@ on the param, f 38;
 #X obj 54 365 ossia.remote Attrs;
 #X text 49 447 only 3 attributes are local to each ø.remote:;
 #N canvas 1186 472 430 103 rate 0;
-#X text 22 31 the rate atrribute determines the update rate at which
+#X text 22 31 the rate attribute determines the update rate at which
 values are polled/triggered in pd;
 #X restore 203 487 pd rate;
 #N canvas 1154 344 469 433 unit 0;

--- a/src/ossia-pd/helps/ossia.view-help.pd
+++ b/src/ossia-pd/helps/ossia.view-help.pd
@@ -40,7 +40,7 @@ leading slash), f 66;
 #X connect 2 0 1 0;
 #X restore 301 182 pd subview;
 #X text 29 129 Also \, models and views can coexist in the same patcher
-(because remotes would'nt know which one to refer to);
+(because remotes wouldn't know which one to refer to);
 #X connect 0 0 5 0;
 #X connect 5 0 0 0;
 #X restore 178 56 pd view;

--- a/src/ossia-pd/src/client.cpp
+++ b/src/ossia-pd/src/client.cpp
@@ -76,7 +76,7 @@ void* client::create(t_symbol* name, int argc, t_atom* argv)
 
     if(find_peer(x))
     {
-      error("Only one [ø.device]/[ø.client] intance per patcher is allowed.");
+      error("Only one [ø.device]/[ø.client] instance per patcher is allowed.");
       client::destroy(x);
       free(x);
       x = nullptr;

--- a/src/ossia-pd/src/model.cpp
+++ b/src/ossia-pd/src/model.cpp
@@ -238,7 +238,7 @@ void* model::create(t_symbol* name, int argc, t_atom* argv)
 
     if(find_peer(x))
     {
-      error("Only one [ø.model]/[ø.view] intance per patcher is allowed.");
+      error("Only one [ø.model]/[ø.view] instance per patcher is allowed.");
       model::destroy(x);
       free(x);
       x = nullptr;

--- a/src/ossia-pd/src/object_base.cpp
+++ b/src/ossia-pd/src/object_base.cpp
@@ -329,7 +329,7 @@ object_base::~object_base()
 
     // or not... because if the patcher is not closed but
     // all its ossia objects are deleted, then if we add one
-    // it can't be registred because it won't find its root
+    // it can't be registered because it won't find its root
     // in the root patcher list.
 
     // TODO fix this, as of 2019.06.24 this seems weird and I think we can remove the

--- a/src/ossia-pd/src/utils.hpp
+++ b/src/ossia-pd/src/utils.hpp
@@ -33,7 +33,7 @@ struct measure
   }
 };
 
-#pragma mark Value type convertion helper
+#pragma mark Value type conversion helper
 
 struct value2atom
 {
@@ -534,7 +534,7 @@ ossia::val_type symbol2val_type(t_symbol* s);
 t_symbol* val_type2symbol(ossia::val_type t);
 
 /**
- * @brief symbol2bounding_mode convert t_symbol* to corresponging ossia::bounding_mode
+ * @brief symbol2bounding_mode convert t_symbol* to corresponding ossia::bounding_mode
  * @param t_symbol* bounding_mode
  * @return ossia::bounding_mode
  */

--- a/src/ossia-pd/src/view.cpp
+++ b/src/ossia-pd/src/view.cpp
@@ -203,7 +203,7 @@ void* view::create(t_symbol* name, int argc, t_atom* argv)
 
     if(find_peer(x))
     {
-      error("Only one [ø.model]/[ø.view] intance per patcher is allowed.");
+      error("Only one [ø.model]/[ø.view] instance per patcher is allowed.");
       view::destroy(x);
       free(x);
       x = nullptr;

--- a/src/ossia-python/pyossia/__init__.py
+++ b/src/ossia-python/pyossia/__init__.py
@@ -4,7 +4,7 @@
 """
 Introduction
 ============
-pyossia module will add usefull access for end users to C++ binded objects of libossia
+pyossia module will add useful access for end users to C++ binded objects of libossia
 
 
 Change log
@@ -20,7 +20,7 @@ pyossia methods
 #import sys to get exception description
 import sys
 
-# these few lines are used to get versionning from git
+# these few lines are used to get versioning from git
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
@@ -84,7 +84,7 @@ def expose(self, protocol='oscquery', host='localhost', listening_port=3456, sen
         print('ossia warning : ' + protocol + ' is not implemented')
 
 ######################################################
-# Following functions are here for conveniance over ossia_python bindings
+# Following functions are here for convenience over ossia_python bindings
 # and might be add to libossia bindings later.
 ######################################################
 
@@ -154,7 +154,7 @@ def get_nodes(self, node=None, depth=0):
 def get_parameters(self, node=None, depth=0):
     """
     return a list of all params for the device
-    depth = 0 returns parameters recursivly for all its children
+    depth = 0 returns parameters recursively for all its children
     depth = 1 returns only the parameters for this node
     depth = 2 returns only the parameters for this node and its children
     """

--- a/src/ossia-python/versioneer.py
+++ b/src/ossia-python/versioneer.py
@@ -180,7 +180,7 @@ two common reasons why `setup.py` might not be in the root:
   `setup.cfg`, and `tox.ini`. Projects like these produce multiple PyPI
   distributions (and upload multiple independently-installable tarballs).
 * Source trees whose main purpose is to contain a C library, but which also
-  provide bindings to Python (and perhaps other langauges) in subdirectories.
+  provide bindings to Python (and perhaps other languages) in subdirectories.
 
 Versioneer will look for `.git` in parent directories, and most operations
 should get the right version string. However `pip` and `setuptools` have bugs

--- a/src/ossia-unity3d/unity3d/ExposeAttributes.cs
+++ b/src/ossia-unity3d/unity3d/ExposeAttributes.cs
@@ -7,7 +7,7 @@ namespace Ossia
 {
 
   //! Expose an object through ossia.
-  //! This shows only the transform and the fields explicitely marked with [Ossia.Expose].
+  //! This shows only the transform and the fields explicitly marked with [Ossia.Expose].
   public class ExposeAttributes : ExposedObject
   {
     void RegisterComponent(Component component)

--- a/src/ossia/dataflow/data.cpp
+++ b/src/ossia/dataflow/data.cpp
@@ -289,7 +289,7 @@ static void filter_value(
 
 void value_port::add_local_value(const ossia::typed_value& other)
 {
-  // These values come from the local environemnt
+  // These values come from the local environment
   // Convert to the correct type / index
   if(other.index == index && other.type == type)
   {

--- a/src/ossia/dataflow/nodes/faust/faust_utils.hpp
+++ b/src/ossia/dataflow/nodes/faust/faust_utils.hpp
@@ -643,7 +643,7 @@ struct custom_dsp_poly_factory : public dsp_factory
    *
    * @param nvoices - number of polyphony voices, should be at least 1
    * @param control - whether voices will be dynamically allocated and
-   * controlled (typically by a MIDI controler). If false all voices are always
+   * controlled (typically by a MIDI controller). If false all voices are always
    * running.
    * @param group - if true, voices are not individually accessible, a global
    * "Voices" tab will automatically dispatch a given control on all voices,

--- a/src/ossia/dataflow/nodes/midi.hpp
+++ b/src/ossia/dataflow/nodes/midi.hpp
@@ -154,7 +154,7 @@ public:
     m_orig_notes = m_notes;
 
     auto max_it = m_notes.lower_bound({m_prev_date});
-    if(max_it != m_notes.begin()) // TODO handle hte begin case correctly
+    if(max_it != m_notes.begin()) // TODO handle the begin case correctly
       m_notes.erase(m_notes.begin(), max_it);
   }
 

--- a/src/ossia/dataflow/nodes/sound_mmap.hpp
+++ b/src/ossia/dataflow/nodes/sound_mmap.hpp
@@ -292,7 +292,7 @@ public:
           }
           else
           {
-            // Otherwise we don't need transport, everything is alreayd at 0
+            // Otherwise we don't need transport, everything is already at 0
             m_prev_date = 0_tv;
           }
         }

--- a/src/ossia/dataflow/nodes/sound_sampler.hpp
+++ b/src/ossia/dataflow/nodes/sound_sampler.hpp
@@ -96,7 +96,7 @@ struct sound_sampler
           }
           else
           {
-            // Otherwise we don't need transport, everything is alreayd at 0
+            // Otherwise we don't need transport, everything is already at 0
             info->m_prev_date = 0_tv;
           }
         }

--- a/src/ossia/dataflow/token_request.hpp
+++ b/src/ossia/dataflow/token_request.hpp
@@ -181,7 +181,7 @@ struct token_request
   [[nodiscard]] constexpr bool backward() const noexcept { return date < prev_date; }
 
   //! Given a quantification rate (1 for bars, 2 for half, 4 for quarters...)
-  //! return the next occuring quantification date, if such date is in the tick
+  //! return the next occurring quantification date, if such date is in the tick
   //! defined by this token_request.
   [[nodiscard]] constexpr std::optional<time_value>
   get_quantification_date(double rate) const noexcept

--- a/src/ossia/editor/scenario/clock.cpp
+++ b/src/ossia/editor/scenario/clock.cpp
@@ -269,7 +269,7 @@ void clock::thread_callback()
   }
   catch(...)
   {
-    logger().error("An error occured in clock::threadCallback()");
+    logger().error("An error occurred in clock::threadCallback()");
   }
 }
 }

--- a/src/ossia/editor/scenario/time_event.hpp
+++ b/src/ossia/editor/scenario/time_event.hpp
@@ -100,32 +100,32 @@ public:
 
   /**
    * @brief getOffsetValue Returns the value of the condition if
-   * we are offseting past this time event.
+   * we are offsetting past this time event.
    */
   [[nodiscard]] offset_behavior get_offset_behavior() const;
 
   /**
-   * @brief setOffsetValue Sets the value of the condition if we are offseting
+   * @brief setOffsetValue Sets the value of the condition if we are offsetting
    * past this time event.
    */
   time_event& set_offset_behavior(offset_behavior);
 
-  /*! get previous time contraints attached to the event
+  /*! get previous time constraints attached to the event
    \return #Container<#time_interval> */
   auto& previous_time_intervals() { return m_previous_time_intervals; }
 
-  /*! get previous time contraints attached to the event
+  /*! get previous time constraints attached to the event
    \return #Container<#TimeProcess> */
   [[nodiscard]] const auto& previous_time_intervals() const
   {
     return m_previous_time_intervals;
   }
 
-  /*! get next time contraints attached to the event
+  /*! get next time constraints attached to the event
    \return #Container<#time_interval> */
   auto& next_time_intervals() { return m_next_time_intervals; }
 
-  /*! get next time contraints attached to the event
+  /*! get next time constraints attached to the event
    \return #Container<#TimeProcess> */
   [[nodiscard]] const auto& next_time_intervals() const { return m_next_time_intervals; }
 

--- a/src/ossia/editor/scenario/time_interval.hpp
+++ b/src/ossia/editor/scenario/time_interval.hpp
@@ -94,7 +94,7 @@ public:
       time_interval::exec_callback, time_event&, time_event&, time_value = Infinite,
       ossia::time_value = Zero, ossia::time_value = Infinite);
 
-  /*! desctructor */
+  /*! destructor */
   ~time_interval();
 
   /*! start #time_interval */

--- a/src/ossia/math/math_expression.cpp
+++ b/src/ossia/math/math_expression.cpp
@@ -69,7 +69,7 @@ struct perlin;
 template <typename T>
 struct perlin<T, 1> : public exprtk::ifunction<T>
 {
-  const siv::PerlinNoise engine{4u}; // choosen by fair dice roll
+  const siv::PerlinNoise engine{4u}; // chosen by fair dice roll
 
   perlin()
       : exprtk::ifunction<T>{3}

--- a/src/ossia/network/common/device_parameter.hpp
+++ b/src/ossia/network/common/device_parameter.hpp
@@ -23,7 +23,7 @@ public:
   virtual ~device_parameter();
 
   //  Must be called when the hardware send a new value
-  //  (typicaly from an event loop)
+  //  (typically from an event loop)
   //  This will NOT call device_update_value() in order to avoid loop
   void device_value_change_event(const ossia::value& value);
 
@@ -73,7 +73,7 @@ public:
 protected:
   virtual void device_update_value()
   {
-    //  Here should be the code that actualy make the hardware update to
+    //  Here should be the code that actually make the hardware update to
     //  current value
   }
 

--- a/src/ossia/network/dataspace/dataspace.hpp
+++ b/src/ossia/network/dataspace/dataspace.hpp
@@ -18,7 +18,7 @@ namespace ossia
 //! They are sorted by categories: every unit in a category is convertible to
 //! the other units in the same category.<br> Every category (coined
 //! "dataspace") has a neutral unit to/from which conversions are made.<br>
-//! \see opp::node::set_unit for a list of all availble units
+//! \see opp::node::set_unit for a list of all available units
 
 struct OSSIA_EXPORT unit_t final
 {

--- a/src/ossia/network/local/local.cpp
+++ b/src/ossia/network/local/local.cpp
@@ -97,7 +97,7 @@ void multiplex_protocol::set_device(device_base& dev)
   {
     p->set_device(*m_device);
 
-    // Expose all the adresses with callbacks
+    // Expose all the addresses with callbacks
     observe_rec(*p, m_device->get_root_node());
 
     m_protocols.push_back(std::move(p));
@@ -122,7 +122,7 @@ void multiplex_protocol::expose_to(std::unique_ptr<protocol_base> p)
     {
       p->set_device(*m_device);
 
-      // Expose all the adresses with callbacks
+      // Expose all the addresses with callbacks
       observe_rec(*p, m_device->get_root_node());
 
       m_protocols.push_back(std::move(p));

--- a/src/ossia/preset/preset.cpp
+++ b/src/ossia/preset/preset.cpp
@@ -1209,7 +1209,7 @@ void ossia::presets::apply_preset(
     if(remove_first)
     {
       if(!keys.empty())
-        keys.erase(keys.begin()); // first subtring is empty
+        keys.erase(keys.begin()); // first substring is empty
     }
     if(!allow_nonterminal)
     {

--- a/src/ossia/protocols/artnet/artnet_protocol.cpp
+++ b/src/ossia/protocols/artnet/artnet_protocol.cpp
@@ -40,7 +40,7 @@ artnet_protocol::artnet_protocol(
   //  It seem to be possible to send only some value and thus
   //   update at higher frequencies => Work TODO
 
-  //  Do not specify ip adress for now, artnet will choose one
+  //  Do not specify ip address for now, artnet will choose one
   m_node = artnet_new(nullptr, 1);
 
   if(m_node == NULL)

--- a/src/ossia/protocols/joystick/joystick_manager.hpp
+++ b/src/ossia/protocols/joystick/joystick_manager.hpp
@@ -85,7 +85,7 @@ public:
 
     if(!joystick_is_registered(joystick_id))
       throw std::runtime_error(
-          "Cannot unregister a protocol that havent been registered");
+          "Cannot unregister a protocol that haven't been registered");
 
     {
       std::lock_guard<std::mutex> _{m_joystick_protocols_mutex};

--- a/src/ossia/protocols/joystick/joystick_protocol.cpp
+++ b/src/ossia/protocols/joystick/joystick_protocol.cpp
@@ -16,7 +16,7 @@ joystick_protocol::joystick_protocol(
     , m_joystick_id{joystick_id}
 {
   //  Check That (ID, Index) is a valid combinaison
-  //  Could happen if a joystick is unpluged bettween settings and here
+  //  Could happen if a joystick is unplugged between settings and here
   if(joystick_id != SDL_JoystickGetDeviceInstanceID(joystick_index))
     throw std::runtime_error("Invalid Settings");
 
@@ -46,7 +46,7 @@ void joystick_protocol::set_device(ossia::net::device_base& dev)
   m_device = &dev;
   auto& root = dev.get_root_node();
 
-  //  Retrive Joystick Info
+  //  Retrieve Joystick Info
   const int axis_count = SDL_JoystickNumAxes(m_joystick);
   // const int ball_count = SDL_JoystickNumBalls(m_joystick);
   const int hat_count = SDL_JoystickNumHats(m_joystick);

--- a/src/ossia/protocols/midi/midi_node.hpp
+++ b/src/ossia/protocols/midi/midi_node.hpp
@@ -32,7 +32,7 @@ public:
   std::unique_ptr<node_base> make_child(const std::string& name) override;
   void removing_child(node_base& node_base) final override;
 
-  //! Explicitely add a child node (which has to be valid)
+  //! Explicitly add a child node (which has to be valid)
   midi_node* add_midi_node(std::unique_ptr<midi_node> n);
 };
 }

--- a/src/ossia/protocols/wiimote/wiimote_protocol.cpp
+++ b/src/ossia/protocols/wiimote/wiimote_protocol.cpp
@@ -286,7 +286,7 @@ void wiimote_protocol::handle_wiimote_event(const unsigned int wiimote_id)
     }
   }
 
-  // If a nunchuk is pluged
+  // If a nunchuk is plugged
   if(m_wiimotes[wiimote_id]->exp.type == EXP_NUNCHUK)
   {
     struct nunchuk_t* nunchuk = (nunchuk_t*)&(m_wiimotes[wiimote_id]->exp.nunchuk);


### PR DESCRIPTION
Found via `codespell -q 3 -L aparent,catched,childrens,devicest,nd,nin,searchs`