### PR TITLE
osc to ws test fix

### DIFF
--- a/src/ossia/network/oscquery/oscquery_server.cpp
+++ b/src/ossia/network/oscquery/oscquery_server.cpp
@@ -31,9 +31,6 @@ namespace oscquery
 static uintptr_t
 client_identifier(const clients& clts, const oscpack::IpEndpointName& ip)
 {
-  if(clts.size() == 1)
-    return (uintptr_t)clts[0]->connection.lock().get();
-
   for(const auto& client_p : clts)
   {
     auto& c = *client_p;

--- a/src/ossia/protocols/oscquery/oscquery_server_asio.cpp
+++ b/src/ossia/protocols/oscquery/oscquery_server_asio.cpp
@@ -40,9 +40,6 @@ struct oscquery_server_protocol::osc_receiver_impl : ossia::net::udp_receive_soc
 static uintptr_t
 client_identifier(const clients& clts, const oscpack::IpEndpointName& ip)
 {
-  if(clts.size() == 1)
-    return (uintptr_t)clts[0]->connection.lock().get();
-
   for(const auto& client_p : clts)
   {
     auto& c = *client_p;

--- a/tests/Network/OSCQueryTest.cpp
+++ b/tests/Network/OSCQueryTest.cpp
@@ -1141,6 +1141,7 @@ TEST_CASE("test_oscquery_osc_to_ws", "test_oscquery_osc_to_ws")
   ossia::net::parameter_base* server_param{};
   {
     auto& n = find_or_create_node(serv, "/main");
+    n.set(critical_attribute{}, true);
     server_param = n.create_parameter(ossia::val_type::FLOAT);
     server_param->push_value(6);
   }


### PR DESCRIPTION
all the other tests pass as well.

I figure this might add more echo back if you have a client that uses both WS and UDP, so I could wrap this in a settable attribute instead.

I added critical to the attribute in the test to assure that the update comes through the WS