### PR TITLE
[osc] crashfix when receiving an OSC message during the generic_device creation

### DIFF
--- a/src/ossia/network/osc/osc.cpp
+++ b/src/ossia/network/osc/osc.cpp
@@ -254,6 +254,11 @@ bool osc_protocol::echo_incoming_message(
 void osc_protocol::on_received_message(
     const oscpack::ReceivedMessage& m, const oscpack::IpEndpointName& ip)
 {
+  [[unlikely]] if(!m_device)
+  {
+    return;
+  }
+
   [[unlikely]] if(m_learning)
   {
     auto already_learned = ossia::net::osc_learn(&m_device->get_root_node(), m);


### PR DESCRIPTION
This code crashes if an OSC message is received between the osc_protocol creation and the generic_device creation.
`	oscDevice = std::make_unique<ossia::net::generic_device>(
	  std::make_unique<ossia::net::osc_protocol>("127.0.0.1", 9996, 9997, std::string("mydevice")),
	  "P");
`

Another fix would be to call osc_protocol::update_receiver() only when the device is set, but I think it is less readable.
