### PR TITLE
Point ExprTk to release branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,6 +37,7 @@
 [submodule "3rdparty/exprtk"]
     path = 3rdparty/exprtk
     url = https://github.com/ArashPartow/exprtk
+    branch = release
 [submodule "3rdparty/SmallFunction"]
     path = 3rdparty/SmallFunction
     url = https://github.com/jcelerier/SmallFunction


### PR DESCRIPTION
Would like to have libossia use the release branch, as I'm about to do a C++17 refactor on master which may get messy in the near term.