### PR TITLE
win32: keep a winsock instance alive during tests to fix spurious CI failures

### DIFF
--- a/tests/catch/include_catch.hpp
+++ b/tests/catch/include_catch.hpp
@@ -8,3 +8,11 @@
 #endif
 #include <iostream>
 #include <fstream>
+
+#if defined(_WIN32)
+#include <winsock2.h>
+static const struct ossia_test_winsock_owner {
+  ossia_test_winsock_owner() { WSADATA d; ::WSAStartup(MAKEWORD(2, 2), &d); }
+  ~ossia_test_winsock_owner() { ::WSACleanup(); }
+} ossia_test_winsock_owner_instance;
+#endif


### PR DESCRIPTION
## Summary

Restores the lost fix (originally `e5ea48d`) for the spurious Win32 CI test failures caused by WinSock being torn down between operations.

asio refcounts `WSAStartup`/`WSACleanup` per object, so during the test run WinSock can be cleaned up between operations, producing intermittent socket failures on the Win32 runners (e.g. https://github.com/ossia/libossia/actions/runs/27264509297/job/80518258354).

The fix keeps a WinSock instance alive for the whole lifetime of the test process via a static owner struct in the shared Catch test header (`tests/catch/include_catch.hpp`), which every test pulls in. Library code is unchanged.

```cpp
#if defined(_WIN32)
#include <winsock2.h>
static const struct ossia_test_winsock_owner {
  ossia_test_winsock_owner() { WSADATA d; ::WSAStartup(MAKEWORD(2, 2), &d); }
  ~ossia_test_winsock_owner() { ::WSACleanup(); }
} ossia_test_winsock_owner_instance;
#endif
```

## Test plan

- [ ] Win32 test jobs stay green across repeated CI runs (the failures were intermittent).

https://claude.ai/code/session_01XRmDZYxYXvYGHnnAVQ3j9T

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRmDZYxYXvYGHnnAVQ3j9T)_