### PR TITLE
abseil: disable CMAKE_INCLUDE_CURRENT_DIR for the in-tree build

### DIFF
--- a/cmake/deps/abseil.cmake
+++ b/cmake/deps/abseil.cmake
@@ -15,6 +15,14 @@ if(NOT TARGET absl::strings)
     # get flooded with warnings coming from them.
     set(ABSL_USE_SYSTEM_INCLUDES ON CACHE INTERNAL "")
 
+    # A consumer with CMAKE_INCLUDE_CURRENT_DIR enabled would otherwise add each
+    # Abseil target's own source/binary dir as a plain -I. For the absl/time
+    # target that injects -I.../absl/time, whose time.h then shadows the system
+    # C <time.h> (e.g. when pthread.h does #include <time.h>), breaking the
+    # build with "no member named 'clock_t' in the global namespace" errors.
+    # Abseil includes its own headers as absl/... so it does not need this.
+    set(CMAKE_INCLUDE_CURRENT_DIR OFF)
+
     # Abseil's CMakeLists forcibly overrides CMAKE_MSVC_RUNTIME_LIBRARY from its
     # own ABSL_MSVC_STATIC_RUNTIME option (default OFF -> /MD), ignoring what the
     # rest of the build selected. Static ossia builds (Max/PD/Python/Unity, ...)


### PR DESCRIPTION
## Problem

Building a consumer that enables `CMAKE_INCLUDE_CURRENT_DIR` (e.g. [ossia score](https://github.com/ossia/score), which sets it globally) fails when compiling the in-tree Abseil with:

```
.../include/c++/14/ctime:60:11: error: no member named 'clock_t' in the global namespace; did you mean '__clock_t'?
   60 |   using ::clock_t;
```

### Root cause

`CMAKE_INCLUDE_CURRENT_DIR ON` makes CMake add **every** target's own source/binary dir as a plain `-I`. For Abseil's `absl/time` target this injects:

```
-I.../abseil-cpp/absl/time
```

That directory contains a header literally named `time.h` (`absl::Time`). Being a plain `-I`, it sits ahead of `/usr/include`, so when a system header does `#include <time.h>` (e.g. `pthread.h`), the compiler resolves it to **Abseil's** `absl/time/time.h` instead of the C `<time.h>`. The C global-namespace symbols (`::clock_t`, `::clock`, …) are then never declared, and `<ctime>`'s `using ::clock_t;` fails.

## Fix

Set `CMAKE_INCLUDE_CURRENT_DIR OFF` inside the existing `block()` scope in `cmake/deps/abseil.cmake`, so it applies only to the Abseil subtree. Abseil includes its own headers as `absl/...` (via the `-isystem` root) and does not rely on this setting, so the change is safe and scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)