### PR TITLE
joystick: use 0..1 domain for game controller triggers

### DIFF
--- a/src/ossia/protocols/joystick/game_controller_protocol.cpp
+++ b/src/ossia/protocols/joystick/game_controller_protocol.cpp
@@ -107,9 +107,12 @@ void game_controller_protocol::set_device(ossia::net::device_base& dev)
     if(SDL_GameControllerHasAxis(m_joystick, static_cast<SDL_GameControllerAxis>(i))
        == SDL_TRUE)
     {
+      // Triggers range from 0 to 1, while sticks range from -1 to 1.
+      const bool is_trigger = (i == SDL_CONTROLLER_AXIS_TRIGGERLEFT
+                               || i == SDL_CONTROLLER_AXIS_TRIGGERRIGHT);
       m_axis_parameters[i] = device_parameter::create_device_parameter(
           root, axes[i], 0.0, val_type::FLOAT, bounding_mode::CLIP, access_mode::GET,
-          make_domain(-1.0f, 1.0f));
+          is_trigger ? make_domain(0.0f, 1.0f) : make_domain(-1.0f, 1.0f));
     }
   }
 


### PR DESCRIPTION
## Summary

Game controller triggers (`SDL_CONTROLLER_AXIS_TRIGGERLEFT` / `TRIGGERRIGHT`) range from 0 to 1, but the axis loop in `game_controller_protocol::set_device` gave every axis the same `-1..1` domain. This broke automatic ranging — e.g. mapping a trigger (intended 0..1) onto a 0..200 Hz parameter started at -200 Hz.

The raw SDL value is already normalized to 0..1 for triggers in `push_axis` (`(ev.value + .5f) / (0x7FFF + .5f)` with trigger raw values in 0..32767), so only the declared domain was wrong.

## Fix

Pick the domain per-axis: `0..1` for the two trigger axes, `-1..1` for the sticks.

Relates to ossia/score#1854

🤖 Generated with [Claude Code](https://claude.com/claude-code)