### PR TITLE
wasm: miniaudio audio-worklet fixes (tick guard + stack size)

### DIFF
--- a/src/ossia/audio/miniaudio_protocol.hpp
+++ b/src/ossia/audio/miniaudio_protocol.hpp
@@ -206,7 +206,8 @@ private:
 
     ossia::audio_tick_state ts{(float* const*)ins,     outs,    self.effective_inputs,
                                self.effective_outputs, nframes, nsecs};
-    self.audio_tick(ts);
+    if(self.audio_tick)
+      self.audio_tick(ts);
 
     self.tick_end();
 

--- a/src/ossia/audio/miniaudio_protocol.hpp
+++ b/src/ossia/audio/miniaudio_protocol.hpp
@@ -14,6 +14,13 @@
 #if defined(__EMSCRIPTEN__)
 #define MA_ENABLE_WEBAUDIO 1
 #define MA_ENABLE_AUDIO_WORKLETS 1
+// The AudioWorklet thread runs the whole ossia execution tick (every node,
+// including deep gfx/ISF exec-node call chains). miniaudio allocates a fixed
+// heap buffer for that thread's stack; its 128KB default is far too small and
+// a deep tick silently overruns it, corrupting adjacent heap allocations
+// (manifesting much later as OOB / null-function crashes on the main thread).
+// Give it a desktop-sized stack instead.
+#define MA_AUDIO_WORKLETS_THREAD_STACK_SIZE 4194304
 #else
 #define MA_ENABLE_COREAUDIO 1
 #define MA_ENABLE_ALSA 1


### PR DESCRIPTION
Two small WASM AudioWorklet fixes in the miniaudio backend.

**Don't call the tick before it is set.** The device is started in the miniaudio engine constructor, before `start_engine` wires up the tick via `set_tick`. On WASM the audio worklet fires promptly and can reach the callback before any tick is loaded, calling an empty `smallfun` (null `vtbl_call`) — a null-function trap. Guard it so an unset tick just yields silence.

**Give the AudioWorklet thread a larger stack.** That thread runs the whole ossia execution tick, including deep gfx/ISF exec-node call chains. miniaudio's default 128KB stack is far too small; a deep tick silently overruns the heap-allocated stack buffer and corrupts adjacent allocations, surfacing much later as out-of-bounds / null-function crashes on the main thread. Bumped to 4MB on WASM.