### PR TITLE
audio: enable miniaudio WASAPI backend on Windows

### DIFF
--- a/src/ossia/audio/miniaudio_protocol.hpp
+++ b/src/ossia/audio/miniaudio_protocol.hpp
@@ -21,6 +21,8 @@
 // (manifesting much later as OOB / null-function crashes on the main thread).
 // Give it a desktop-sized stack instead.
 #define MA_AUDIO_WORKLETS_THREAD_STACK_SIZE 4194304
+#elif defined(_WIN32)
+#define MA_ENABLE_WASAPI 1
 #else
 #define MA_ENABLE_COREAUDIO 1
 #define MA_ENABLE_ALSA 1
@@ -87,10 +89,18 @@ public:
 
     config.sampleRate = rate;
     config.periodSizeInFrames = bs;
+    // A zeroed device id means "system default device". Passing NULL as the
+    // pDeviceID makes miniaudio open the OS default device and, on backends
+    // that support it (WASAPI in particular), automatically follow the OS
+    // default output/input when the user changes it while the stream runs.
+    auto is_default_id = [](const ma_device_id& id) {
+      ma_device_id zero{};
+      return memcmp(&id, &zero, sizeof(ma_device_id)) == 0;
+    };
 
     if(outputs > 0)
     {
-      config.playback.pDeviceID = &card_out;
+      config.playback.pDeviceID = is_default_id(card_out) ? nullptr : &card_out;
       config.playback.channels = outputs;
       config.playback.format = ma_format_f32;
       // config.playback.shareMode = ma_share_mode_exclusive;
@@ -98,7 +108,7 @@ public:
 
     if(inputs > 0)
     {
-      config.capture.pDeviceID = &card_in;
+      config.capture.pDeviceID = is_default_id(card_in) ? nullptr : &card_in;
       config.capture.channels = inputs;
       config.capture.format = ma_format_f32;
       // config.capture.shareMode = ma_share_mode_exclusive;

--- a/src/ossia_features.cmake
+++ b/src/ossia_features.cmake
@@ -281,24 +281,22 @@ if(OSSIA_DATAFLOW)
   # miniaudio.cpp; consumers (score-plugin-audio) only see declarations and
   # link the exported API, so there is no duplicate ma_* symbol when everything
   # is statically linked into one binary.
-  if(TRUE)
-    target_sources(ossia PRIVATE
-      "${CMAKE_CURRENT_SOURCE_DIR}/ossia/audio/miniaudio.cpp")
-    # Keep it its own TU: it is the only place MINIAUDIO_IMPLEMENTATION is
-    # defined, and unity-merging could reorder it past a declarations-only
-    # include and drop the implementation.
-    set_source_files_properties(
-      "${CMAKE_CURRENT_SOURCE_DIR}/ossia/audio/miniaudio.cpp"
-      PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
-    target_include_directories(ossia PRIVATE $<BUILD_INTERFACE:${OSSIA_3RDPARTY_FOLDER}/miniaudio>)
-    if(APPLE)
-      # miniaudio's CoreAudio backend, built with MA_NO_RUNTIME_LINKING.
-      target_link_libraries(ossia PRIVATE
-        "-framework CoreAudio" "-framework AudioToolbox"
-        "-framework AudioUnit" "-framework CoreFoundation")
-    elseif(CMAKE_SYSTEM_NAME MATCHES Emscripten)
-      target_link_options(ossia PUBLIC -sAUDIO_WORKLET=1 -sWASM_WORKERS=1)
-    endif()
+  target_sources(ossia PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/ossia/audio/miniaudio.cpp")
+  # Keep it its own TU: it is the only place MINIAUDIO_IMPLEMENTATION is
+  # defined, and unity-merging could reorder it past a declarations-only
+  # include and drop the implementation.
+  set_source_files_properties(
+    "${CMAKE_CURRENT_SOURCE_DIR}/ossia/audio/miniaudio.cpp"
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+  target_include_directories(ossia PRIVATE $<BUILD_INTERFACE:${OSSIA_3RDPARTY_FOLDER}/miniaudio>)
+  if(APPLE)
+    # miniaudio's CoreAudio backend, built with MA_NO_RUNTIME_LINKING.
+    target_link_libraries(ossia PRIVATE
+      "-framework CoreAudio" "-framework AudioToolbox"
+      "-framework AudioUnit" "-framework CoreFoundation")
+  elseif(CMAKE_SYSTEM_NAME MATCHES Emscripten)
+    target_link_options(ossia PUBLIC -sAUDIO_WORKLET=1 -sWASM_WORKERS=1)
   endif()
 
   if(OSSIA_ENABLE_LIBSAMPLERATE)

--- a/src/ossia_features.cmake
+++ b/src/ossia_features.cmake
@@ -276,12 +276,12 @@ if(OSSIA_DATAFLOW)
     target_link_libraries(ossia PRIVATE $<BUILD_INTERFACE:ossia::sdl2>)
   endif()
 
-  # MiniAudio (CoreAudio on macOS, ALSA on Linux, Web Audio on wasm).
-  # The single-header implementation is compiled here, once, in miniaudio.cpp;
-  # consumers (score-plugin-audio) only see declarations and link the exported
-  # API, so there is no duplicate ma_* symbol when everything is statically
-  # linked into one binary. Not used on Windows (WASAPI/PortAudio there).
-  if(NOT WIN32)
+  # MiniAudio (WASAPI on Windows, CoreAudio on macOS, ALSA on Linux, Web Audio
+  # on wasm). The single-header implementation is compiled here, once, in
+  # miniaudio.cpp; consumers (score-plugin-audio) only see declarations and
+  # link the exported API, so there is no duplicate ma_* symbol when everything
+  # is statically linked into one binary.
+  if(TRUE)
     target_sources(ossia PRIVATE
       "${CMAKE_CURRENT_SOURCE_DIR}/ossia/audio/miniaudio.cpp")
     # Keep it its own TU: it is the only place MINIAUDIO_IMPLEMENTATION is


### PR DESCRIPTION
## What

Enables the miniaudio backend on Windows (WASAPI) and lets the miniaudio engine
follow the OS default device on the fly. Groundwork for the new "WASAPI
(miniaudio)" audio driver in ossia score.

## Changes

- **`src/ossia/audio/miniaudio_protocol.hpp`**
  - Enable `MA_ENABLE_WASAPI` on `_WIN32`. Previously no miniaudio backend was
    enabled there (only CoreAudio/ALSA on Unix, WebAudio on wasm), so miniaudio
    was effectively unavailable on Windows.
  - `miniaudio_engine`: treat an all-zero `ma_device_id` as "system default
    device" and pass `pDeviceID = NULL` to `ma_device_init`. On WASAPI this
    opens the OS default endpoint and enables automatic stream routing, so
    playback/capture follow the Windows mixer default when it changes while the
    stream is running. Backward compatible: the generic default-fallback path
    and the WebAudio backend already pass zeroed ids.

- **`src/ossia_features.cmake`**
  - Compile the single `miniaudio.cpp` implementation TU on Windows too (was
    gated behind `NOT WIN32`). Kept as its own non-unity TU as before.

## Notes

- No new link-time dependencies: miniaudio's WASAPI backend uses runtime
  linking on Windows.
- Other platforms are unaffected (same backends, same behavior).

## Testing

Built and linked into ossia score on Windows (clang64). Verified at runtime that
the WASAPI context initializes, devices enumerate, and `ma_device_init` +
`ma_device_start` succeed for both an explicit device id and the default
(`pDeviceID = NULL`) path.

## Disclosure

The implementation in this PR was produced with an AI coding 
agent (Anthropic's Claude Opus 4.8) using [omp](https://omp.sh/).
I directed the work, reviewed every change, and ran the verification
described above; I take responsibility for its correctness and licensing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>