### PR TITLE
libav: add host hook for custom-IO avformat open

### DIFF
--- a/src/ossia/detail/libav.hpp
+++ b/src/ossia/detail/libav.hpp
@@ -68,12 +68,24 @@ static inline int avstream_get_audio_channels(AVStream& stream) noexcept
 #endif
 }
 
+// Opens path over custom IO; returns nullptr if it does not handle that path.
+// io_owner/io_free hand back the streaming resources for cleanup() to release.
+using libav_open_hook
+    = AVFormatContext* (*)(const char* path, void*& io_owner, void (*&io_free)(void*));
+inline libav_open_hook& libav_custom_open() noexcept
+{
+  static libav_open_hook hook = nullptr;
+  return hook;
+}
+
 struct libav_handle
 {
   AVFormatContext* format{};
   AVStream* stream{};
   AVCodecContext* codec{};
   SwrContext* resample{};
+  void* io_owner{};
+  void (*io_free)(void*){};
 
   libav_handle() = default;
   libav_handle(const libav_handle& other) = delete;
@@ -87,6 +99,10 @@ struct libav_handle
     other.codec = nullptr;
     resample = other.resample;
     other.resample = nullptr;
+    io_owner = other.io_owner;
+    other.io_owner = nullptr;
+    io_free = other.io_free;
+    other.io_free = nullptr;
   }
   libav_handle& operator=(const libav_handle& other) = delete;
   libav_handle& operator=(libav_handle&& other)
@@ -99,6 +115,10 @@ struct libav_handle
     other.codec = nullptr;
     resample = other.resample;
     other.resample = nullptr;
+    io_owner = other.io_owner;
+    other.io_owner = nullptr;
+    io_free = other.io_free;
+    other.io_free = nullptr;
     return *this;
   }
   ~libav_handle()
@@ -122,11 +142,21 @@ struct libav_handle
       avformat_free_context(format);
       format = nullptr;
     }
+    if(io_owner)
+    {
+      io_free(io_owner);
+      io_owner = nullptr;
+      io_free = nullptr;
+    }
   }
 
   void open(const std::string& path, int stream_index, int target_rate) noexcept
   {
-    if(avformat_open_input(&format, path.c_str(), nullptr, nullptr) != 0)
+    if(auto hook = libav_custom_open())
+      format = hook(path.c_str(), io_owner, io_free);
+
+    if(!format
+       && avformat_open_input(&format, path.c_str(), nullptr, nullptr) != 0)
     {
       cleanup();
       return;


### PR DESCRIPTION
Adds an optional host hook to `libav_handle::open()` so a host can supply an
`AVFormatContext` opened over a custom `AVIOContext` instead of the default
fopen-based path.

The motivation is the WebAssembly build of score: media dropped into the browser
lives behind a `Blob` URL (`weblocalfile:`) that `fopen` cannot open at all, so
multi-GB files currently have to be copied into the 2 GB wasm heap before they can
be decoded. With this hook, score installs its own opener that streams the Blob
byte-range by byte-range, and nothing is ever fully buffered.

Design notes:

- **No Qt, no emscripten, nothing new in libossia.** The hook is a plain function
  pointer; all of the streaming machinery lives on the score side.
- **Opt-in and inert by default.** The hook is null unless a host installs one, and
  returning `nullptr` from it means "I do not handle this path", which falls straight
  back to `avformat_open_input`. Existing behaviour is unchanged.
- **Ownership is handed back explicitly.** The hook fills in `io_owner` / `io_free`,
  which `libav_handle` stores and releases in `cleanup()` *after* the format context
  is freed, so the AVIO buffer outlives its consumer. Both are moved along in the
  move constructor and move assignment.

+34 / −1, header-only, in `src/ossia/detail/libav.hpp`.

**Paired with ossia/score#2148** — score's `wasm-tier-b` bumps the submodule to this
commit and is what actually installs the hook. This one should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oPj1zRcxSQX7FNni7EHM6
