### PR TITLE
deps: do not make the system rapidfuzz and spdlog mandatory

### DIFF
--- a/cmake/deps/rapidfuzz.cmake
+++ b/cmake/deps/rapidfuzz.cmake
@@ -1,6 +1,6 @@
 ossia_use_system(use_sys rapidfuzz)
 if(use_sys)
-  find_package(rapidfuzz CONFIG REQUIRED GLOBAL)
+  find_package(rapidfuzz CONFIG GLOBAL)
 endif()
 
 if(NOT TARGET rapidfuzz::rapidfuzz)

--- a/cmake/deps/spdlog.cmake
+++ b/cmake/deps/spdlog.cmake
@@ -1,7 +1,7 @@
 ossia_use_system(use_sys spdlog)
 if(use_sys)
   if(NOT OSSIA_FMT_INTERNAL)
-    find_package(spdlog CONFIG REQUIRED GLOBAL)
+    find_package(spdlog CONFIG GLOBAL)
   endif()
 endif()
 


### PR DESCRIPTION
Two files in `cmake/deps/` pass `REQUIRED` to `find_package`, which makes configure abort before their own vendored fallback — the block immediately below — can run:

```cmake
ossia_use_system(use_sys rapidfuzz)
if(use_sys)
  find_package(rapidfuzz CONFIG REQUIRED GLOBAL)   # aborts configure here
endif()

if(NOT TARGET rapidfuzz::rapidfuzz)                # unreachable when use_sys is on
  <vendored fallback using OSSIA_3RDPARTY_FOLDER/rapidfuzz-cpp>
endif()
```

`spdlog.cmake` has the same shape, with its `find_package` additionally nested under `if(NOT OSSIA_FMT_INTERNAL)`.

The result: any build with `OSSIA_USE_SYSTEM_LIBRARIES` on, on a system where rapidfuzz-cpp or spdlog is not packaged, fails at configure instead of using the bundled submodule that is sitting right there. `rapidfuzz-cpp` in particular is packaged in neither oe-core nor meta-openembedded.

This was seen live on a Yocto configure: it logged "Could NOT find concurrentqueue", "Could NOT find ctre" and "Could NOT find mdspan", carried on fine each time, then died hard on rapidfuzz.

### The change

Drop `REQUIRED` from those two `find_package` calls. Nothing else in either file is touched.

```
-  find_package(rapidfuzz CONFIG REQUIRED GLOBAL)
+  find_package(rapidfuzz CONFIG GLOBAL)

-    find_package(spdlog CONFIG REQUIRED GLOBAL)
+    find_package(spdlog CONFIG GLOBAL)
```

This matches every other dependency in the directory — `concurrentqueue.cmake` and `fmt.cmake` are the closest reference examples.

### Which files are affected

`grep -rn REQUIRED cmake/deps/` returns exactly three hits, and only these two are bugs:

| file | verdict |
|---|---|
| `cmake/deps/rapidfuzz.cmake:3` | fixed — `REQUIRED` shadows the fallback below |
| `cmake/deps/spdlog.cmake:4` | fixed — same |
| `cmake/deps/boost.cmake:40` | **left alone, correct** — it sits inside the `if(NOT Boost_FOUND)` branch *after* the tarball has been downloaded and extracted and `BOOST_ROOT` has been set, so the package genuinely must be found at that point |

I also checked every other `find_package` in `cmake/deps/` (28 of them): none of the rest passes `REQUIRED`, so there is no third instance of this pattern.

### Verification

Reasoned from the CMake sources; the bug is structural (an unreachable `if(NOT TARGET ...)` block), and the fix restores the exact shape already used by the other dependency files. Confirmed that `3rdparty/rapidfuzz-cpp` and `3rdparty/spdlog` are declared submodules in `.gitmodules`, so the fallback paths point at content that really exists.

Not verified: no configure or build was run for this change. In particular I did not empirically confirm that the vendored rapidfuzz-cpp / spdlog copies build cleanly on a system where `OSSIA_USE_SYSTEM_LIBRARIES` is on — that is the same code path a non-system build already takes every day, but it has not been exercised in this specific combination here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
