### PR TITLE
cmake: OSSIA_OVERRIDE_PROTOCOLS must write the cache

### DIFF
--- a/cmake/OssiaOptions.cmake
+++ b/cmake/OssiaOptions.cmake
@@ -276,12 +276,12 @@ endif()
 
 if(OSSIA_OVERRIDE_PROTOCOLS)
   foreach(protocol ${OSSIA_AVAILABLE_PROTOCOLS})
-    set(OSSIA_PROTOCOL_${protocol} OFF)
+    set(OSSIA_PROTOCOL_${protocol} OFF CACHE INTERNAL "" FORCE)
   endforeach()
 
   foreach(protocol ${OSSIA_OVERRIDE_PROTOCOLS})
     string(TOUPPER ${protocol} protocol)
-    set(OSSIA_PROTOCOL_${protocol} ON)
+    set(OSSIA_PROTOCOL_${protocol} ON CACHE INTERNAL "" FORCE)
   endforeach()
 endif()
 


### PR DESCRIPTION
The `OSSIA_PROTOCOL_*` entries are created by `option()`, so the plain `set()` in the `OSSIA_OVERRIDE_PROTOCOLS` block shadows them only inside libossia's own directory scope. A consumer in another scope keeps reading the cached value.

The two halves then compile different source sets. With an override that excludes COAP, libossia builds no CoAP support while a dependent project still compiles its CoAP device, and the link fails on `ossia::net::coap_client_protocol`.

Writing the cache makes every scope agree, and matches how the rest of `OssiaOptions.cmake` and `OssiaDeps.cmake` disable protocols.