### PR TITLE
ci: fix the Ubuntu toolchain setup (apt prompts, and the Kitware repo)

### DIFF
--- a/.github/actions/latest-ubuntu-toolchain/action.yml
+++ b/.github/actions/latest-ubuntu-toolchain/action.yml
@@ -15,7 +15,7 @@ runs:
         sudo rm /etc/apt/trusted.gpg.d/kitware.gpg
 
         sudo apt-get update -qq
-        sudo apt purge --auto-remove cmake
+        sudo apt-get purge -yqq --auto-remove cmake
 
         # gcc-14 / clang-19 are in the noble main repo; both ship full C++23
         # support including deducing-this (P0847). No PPA / LLVM repo needed.

--- a/.github/actions/latest-ubuntu-toolchain/action.yml
+++ b/.github/actions/latest-ubuntu-toolchain/action.yml
@@ -7,15 +7,25 @@ runs:
       shell: bash
       run: |
         # Freshest CMake from Kitware, matched to the runner's distro codename.
-        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-        sudo apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
-
-        sudo apt-get update -yqq
-        sudo apt-get install -yqq kitware-archive-keyring
-        sudo rm /etc/apt/trusted.gpg.d/kitware.gpg
+        #
+        # The bootstrap key goes to the exact path kitware-archive-keyring owns,
+        # and the repo is tied to it with signed-by=, so removing the bootstrap
+        # copy below leaves the entry verifiable. The list file is written
+        # directly rather than through apt-add-repository, which rewrites any
+        # pre-existing kitware entry -- the runner image ships one -- and drops
+        # its signed-by in the process.
+        sudo install -d -m 0755 /usr/share/keyrings
+        wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc \
+          | gpg --dearmor - \
+          | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+        echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" \
+          | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 
         sudo apt-get update -qq
-        sudo apt-get purge -yqq --auto-remove cmake
+        # Hand the keyring over to the package so future key rotations arrive as
+        # an ordinary upgrade. It owns the path, so the bootstrap copy goes first.
+        sudo rm -f /usr/share/keyrings/kitware-archive-keyring.gpg
+        sudo apt-get install -yqq kitware-archive-keyring
 
         # gcc-14 / clang-19 are in the noble main repo; both ship full C++23
         # support including deducing-this (P0847). No PPA / LLVM repo needed.

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Run Benchmarks"
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -qq libbenchmark-dev libbenchmark-tools
+          sudo apt-get install -yqq libbenchmark-dev libbenchmark-tools
           cp -rf libossia-device-bench/* .
           mkdir results
           chmod +x ossia_DeviceBenchmark


### PR DESCRIPTION
Two problems in `.github/actions/latest-ubuntu-toolchain`, one fatal and one quiet.

## 1. `apt purge` had no `-y` — this is what is failing now

```
The following packages will be REMOVED:
  cmake*
Do you want to continue? [Y/n] Abort.
##[error]Process completed with exit code 1.
```

It aborts about twenty seconds in, before cmake is ever invoked, taking **ossia-cpp, ossia-qml, ossia-unity and ossia-purrdata** with it on master.

## 2. The Kitware repo was never actually verified

The bootstrap key went to `/etc/apt/trusted.gpg.d/kitware.gpg` and the repo entry carried no `signed-by=`. `kitware-archive-keyring` installs its key at `/usr/share/keyrings/kitware-archive-keyring.gpg` — a *different* path — so once the bootstrap copy was `rm`ed, nothing pointed at a key for that repo:

```
GPG error: https://apt.kitware.com/ubuntu noble InRelease: The following signatures
couldn't be verified because the public key is not available: NO_PUBKEY 65ADECD7A7039392
```

apt then falls back to the cached index, so it degrades quietly instead of failing — until the index needs refreshing or the key rotates.

Two further details: `apt-add-repository` **rewrites** a pre-existing kitware entry (the runner image ships one) and drops its `signed-by` while doing so, which is why the list file is now written directly. And the cmake purge/reinstall existed to force the Kitware build over the distro one — a working repo does that by itself, since apt picks the highest version, so it goes away.

## Verification

Ran both the old and new blocks in a clean `ubuntu:24.04` container.

**New:**
```
apt-get update: no signature errors
keyring package installed; key present: yes
post-handover update: still verified
cmake installed: cmake version 4.4.2
from:  500 https://apt.kitware.com/ubuntu noble/main amd64 Packages
```

**Old** — reproduces the exact key ID from CI:
```
GPG error: ... NO_PUBKEY 65ADECD7A7039392
```

For reference: noble ships cmake `3.28.3`, Kitware has `4.4.2`, and the runner image comes with `3.31.5`/`4.1.2`.

Also gives the `libbenchmark` install in `benchmarks.yml` the same `-y`; it passes today only because nothing extra needs pulling in.
