### PR TITLE
Tracking primitives, plus three fixes found building on them

### DIFF
--- a/cmake/deps/asio-sdk.cmake
+++ b/cmake/deps/asio-sdk.cmake
@@ -9,6 +9,23 @@ if(EXISTS "${ASIO_SDK_DIR}/common/asio.h" AND WIN32)
   # Must not be built with UNICODE/_UNICODE: asiolist.cpp is ANSI-only and
   # enumerates zero drivers if the TCHAR registry calls resolve to -W.
 
+  # The SDK is written against the unabridged <windows.h>. iasiodrv.h declares
+  # IASIO with the `interface` keyword, which is a macro that <windows.h> only
+  # reaches through <ole2.h>, and WIN32_LEAN_AND_MEAN is precisely the switch
+  # that cuts <ole2.h> out - so every translation unit here stops compiling with
+  # "unknown type name 'interface'" as soon as an embedder defines it globally.
+  # score does, for all C++ (see its ScoreConfiguration.cmake), which is why
+  # this cannot be left to the consumer: libossia's own build never defines it,
+  # so the breakage only appears once libossia is built inside score.
+  #
+  # Undo it for this target alone. CMake emits $DEFINES before $FLAGS, so a -U
+  # in the compile options reliably lands after any inherited -D.
+  if(MSVC)
+    target_compile_options(asio_sdk PRIVATE /UWIN32_LEAN_AND_MEAN)
+  else()
+    target_compile_options(asio_sdk PRIVATE -UWIN32_LEAN_AND_MEAN)
+  endif()
+
   target_include_directories(asio_sdk SYSTEM PUBLIC
     $<BUILD_INTERFACE:${ASIO_SDK_DIR}/common>
     $<BUILD_INTERFACE:${ASIO_SDK_DIR}/host>

--- a/src/ossia/dataflow/nodes/forward_node.hpp
+++ b/src/ossia/dataflow/nodes/forward_node.hpp
@@ -3,6 +3,7 @@
 #include <ossia/dataflow/graph_node.hpp>
 #include <ossia/dataflow/midi_port.hpp>
 #include <ossia/dataflow/port.hpp>
+#include <ossia/math/safe_math.hpp>
 namespace ossia::nodes
 {
 class forward_node : public ossia::nonowning_graph_node
@@ -88,6 +89,15 @@ public:
         }
       }
       {
+        ossia::value_port& vp = *m_inlets[2]->target<ossia::value_port>();
+        if(auto& data = vp.get_data(); !data.empty())
+        {
+          const float s = ossia::convert<float>(data.back().value);
+          if(ossia::safe_isfinite(s) && s > no_speed && s < -no_speed)
+            speed_override = s;
+        }
+      }
+      {
         ossia::value_port& vp = *m_inlets[3]->target<ossia::value_port>();
         if(auto& data = vp.get_data(); !data.empty())
         {
@@ -99,7 +109,15 @@ public:
   }
 
   static const constexpr float no_tempo = -1000.f;
+  static const constexpr float no_speed = -1000.f;
   float tempo{no_tempo};
+
+  //! Dimensionless rate multiplier written into the Speed inlet (m_inlets[2]).
+  //! Latched like tempo: the last value written stays in effect.
+  //! Consumed by time_interval::speed_override() as a multiplier on top of
+  //! m_speed, so a phase-locked follower can trim the rate without touching
+  //! BPM semantics.
+  float speed_override{no_speed};
   int64_t seek{std::numeric_limits<int64_t>::min()};
 };
 class loop final : public forward_node

--- a/src/ossia/dataflow/nodes/sound_utils.hpp
+++ b/src/ossia/dataflow/nodes/sound_utils.hpp
@@ -94,8 +94,10 @@ static void read_audio_from_buffer(
     {
       const int64_t read_start = start_offset + start;
 
-      // Absolute best case where we can just copy directly the whole buffer
-      if(read_start + samples_to_write < file_duration)
+      // Absolute best case where we can just copy directly the whole buffer.
+      // read_start can be negative when the transport crosses zero, hence the
+      // lower bound: without it this indexes before the start of the sample.
+      if(read_start >= 0 && read_start + samples_to_write < file_duration)
       {
         for(std::size_t i = 0; i < channels; i++)
         {
@@ -110,7 +112,7 @@ static void read_audio_from_buffer(
       }
       else
       {
-        // Here we must check for the end of file
+        // Here we must check for both ends of the file
         for(std::size_t i = 0; i < channels; i++)
         {
           auto& src = data[i];
@@ -119,7 +121,7 @@ static void read_audio_from_buffer(
           for(int64_t k = 0; k < samples_to_write; k++)
           {
             int64_t pos = read_start + k;
-            if(pos < file_duration)
+            if(pos >= 0 && pos < file_duration)
               dst[k] = src[pos];
             else
               dst[k] = 0;
@@ -137,8 +139,13 @@ static void read_audio_from_buffer(
 
         for(int64_t k = 0; k < samples_to_write; k++)
         {
-          int64_t pos = start_offset + ((start + k) % loop_duration);
-          if(pos < file_duration)
+          // Floor-modulo: the built-in % keeps the sign of the dividend, so a
+          // negative (start + k) would wrap to a negative index.
+          const int64_t raw_pos = start + k;
+          const int64_t wrapped_pos
+              = ((raw_pos % loop_duration) + loop_duration) % loop_duration;
+          const int64_t pos = start_offset + wrapped_pos;
+          if(pos >= 0 && pos < file_duration)
             dst[k] = src[pos];
           else
             dst[k] = 0;
@@ -153,24 +160,33 @@ static void read_audio_from_buffer(
       const auto& src = data[i];
       T* dst = audio_array[i];
 
-      if(file_duration >= start + samples_to_write + start_offset)
+      const int64_t read_start = start + start_offset;
+
+      if(read_start >= 0 && file_duration >= read_start + samples_to_write)
       {
         // Absolute best case where we can copy the whole buffer
-        for(int64_t k = 0, pos = start + start_offset; k < samples_to_write; k++, pos++)
+        for(int64_t k = 0, pos = read_start; k < samples_to_write; k++, pos++)
         {
           dst[k] = src[pos];
         }
       }
       else
       {
-        // This buffer will have the end of the file
-        const int64_t max = ossia::clamp(
-            file_duration - (start + start_offset), (int64_t)0, samples_to_write);
-        for(int64_t k = 0, pos = start + start_offset; k < max; k++, pos++)
+        // This buffer straddles one or both ends of the file: zero-fill the
+        // part before sample 0 (the transport can be before the start when it
+        // crosses zero) and the part past the end.
+        const int64_t lead = ossia::clamp(-read_start, (int64_t)0, samples_to_write);
+        const int64_t max
+            = ossia::clamp(file_duration - read_start, lead, samples_to_write);
+        for(int64_t k = 0; k < lead; k++)
+        {
+          dst[k] = 0;
+        }
+        for(int64_t k = lead, pos = read_start + lead; k < max; k++, pos++)
         {
           dst[k] = src[pos];
         }
-        for(int k = max; k < samples_to_write; k++)
+        for(int64_t k = max; k < samples_to_write; k++)
         {
           dst[k] = 0;
         }

--- a/src/ossia/editor/scenario/time_interval.cpp
+++ b/src/ossia/editor/scenario/time_interval.cpp
@@ -53,8 +53,21 @@ double time_interval::get_speed(time_value date) const noexcept
   }
   else
   {
-    return m_speed * tempo(date) / ossia::root_tempo;
+    return m_speed * speed_override() * tempo(date) / ossia::root_tempo;
   }
+}
+
+double time_interval::speed_override() const noexcept
+{
+  // The Speed inlet only exists once set_tempo_curve created the extra inlets,
+  // which is also the only case in which the callers multiply by this: an
+  // interval without a tempo curve never pays for the check.
+#if defined(OSSIA_SCENARIO_DATAFLOW)
+  const float s = static_cast<ossia::nodes::interval*>(node.get())->speed_override;
+  if(BOOST_UNLIKELY(s != ossia::nodes::interval::no_speed))
+    return s;
+#endif
+  return 1.;
 }
 
 tick_transport_info time_interval::current_transport_info() const noexcept
@@ -131,7 +144,11 @@ void time_interval::tick_impl(
   }
 
   m_current_signature = signature(old_date, parent_request);
-  m_current_tempo = m_speed * tempo(old_date, parent_request);
+  // The Speed inlet folds into the tempo handed to children, not only into the
+  // rate the interval advances at: otherwise token_request::speed would carry
+  // the override while token_request::tempo did not, and every process reading
+  // musical time (bars, quarters) would disagree with the playhead.
+  m_current_tempo = m_speed * speed_override() * tempo(old_date, parent_request);
 
   if(m_hasTempo)
   {
@@ -141,8 +158,27 @@ void time_interval::tick_impl(
   {
     m_globalSpeed = m_parentSpeed * m_speed;
   }
-  if(m_hasSignature)
+  // A tempo-locked interval advances its own date at its own rate, so it must
+  // derive its own musical positions even without a local signature map:
+  // inheriting the parent's would leave musical time disagreeing with the
+  // playhead, so that processes reading token_request::tempo (sound files)
+  // follow the local tempo while those reading the musical grid (Patternist,
+  // metronomes, quantified processes) follow the parent's.
+  if(m_hasSignature || m_hasTempo)
   {
+    const bool has_map = m_hasSignature && !m_timeSignature.empty();
+
+    // Without a local map the grid starts at 0 in the parent's meter.
+    const auto signature_at
+        = [&](ossia::time_value d) -> std::pair<ossia::time_value, ossia::time_signature> {
+      if(has_map)
+      {
+        if(auto it = ossia::last_before(m_timeSignature, d); it != m_timeSignature.end())
+          return {it->first, it->second};
+      }
+      return {ossia::time_value{}, parent_request.signature};
+    };
+
     // Compute the amount of bars for each signature change.
     // We need the exact amount of time that happens between two signature
     // changes.
@@ -157,7 +193,7 @@ void time_interval::tick_impl(
     {
       const double num_quarters = old_date.impl / m_quarter_duration;
 
-      auto [time, sig] = *ossia::last_before(m_timeSignature, old_date);
+      auto [time, sig] = signature_at(old_date);
 
       auto quarters_since_last_measure_change
           = (old_date - time).impl / m_quarter_duration;
@@ -177,7 +213,7 @@ void time_interval::tick_impl(
       auto d = ossia::time_value{new_date.impl};
       const double num_quarters = d.impl / m_quarter_duration;
 
-      auto [time, sig] = *ossia::last_before(m_timeSignature, d);
+      auto [time, sig] = signature_at(d);
 
       auto quarters_since_last_measure_change = (d - time).impl / m_quarter_duration;
       auto quarters_in_bar = (4. * (double(sig.upper) / sig.lower));
@@ -233,7 +269,8 @@ double time_interval::local_time_factor(
     const ossia::token_request& parent_request) const noexcept
 {
   if(BOOST_UNLIKELY(m_hasTempo && parent_request.speed != 0))
-    return (m_speed * tempo(m_date) / ossia::root_tempo) / parent_request.speed;
+    return (m_speed * speed_override() * tempo(m_date) / ossia::root_tempo)
+           / parent_request.speed;
   return m_speed;
 }
 
@@ -298,7 +335,8 @@ void time_interval::tick_offset(
 
     // absolute tempo given : we negate the speed of the parent
     // todo : this should be done outside for the scenario
-    double speed = (m_speed * t0 / ossia::root_tempo) / parent_request.speed;
+    double speed
+        = (m_speed * speed_override() * t0 / ossia::root_tempo) / parent_request.speed;
 
     tick_impl(
         m_date, m_date + take_step(date.impl * speed), to_local_offset(offset, speed),

--- a/src/ossia/editor/scenario/time_interval.hpp
+++ b/src/ossia/editor/scenario/time_interval.hpp
@@ -58,6 +58,11 @@ public:
 
   double get_speed(time_value date) const noexcept;
 
+  //! Dimensionless rate multiplier last written into the interval node's Speed
+  //! inlet, 1. if nothing was ever written there. Only meaningful when the
+  //! interval has a tempo curve, since that is when the inlet exists.
+  double speed_override() const noexcept;
+
   //! The factor between the parent's model time and ours for this tick: the
   //! same one the tick duration is scaled by. A tempo-locked interval runs at
   //! its tempo whatever the transport does, hence the parent-speed division.

--- a/src/ossia/math/filters.hpp
+++ b/src/ossia/math/filters.hpp
@@ -1,0 +1,418 @@
+#pragma once
+#include <ossia/detail/config.hpp>
+
+#include <ossia/detail/math.hpp>
+#include <ossia/detail/small_vector.hpp>
+
+#include <cmath>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <type_traits>
+
+/**
+ * \file filters.hpp
+ *
+ * Allocation-free scalar smoothing filters, meant to be used per-component on
+ * the audio or the execution thread.
+ *
+ * Everything here is an aggregate: trivially copyable, cheap to reset by
+ * assignment, and cheap to keep one per component or per tracked object. No
+ * virtuals, and no transcendentals in the hot path - the low-pass coefficient
+ * is the usual first-order approximation, a single divide.
+ *
+ * The time-varying filters take an explicit dt (in seconds) rather than a fixed
+ * sample rate: score ticks value processes at a variable block rate, so a rate
+ * captured once at prepare() time is wrong as soon as the buffer size changes.
+ */
+
+namespace ossia
+{
+
+/**
+ * @brief Smoothing factor of a first-order low-pass, for a sample spaced
+ * @p dt seconds from the previous one.
+ *
+ * @param cutoff Cutoff frequency, in Hz. Must be > 0.
+ * @param dt Time since the previous sample, in seconds. Must be > 0.
+ * @return alpha in ]0, 1[ ; 1 would be passthrough, 0 a frozen output.
+ */
+template <typename T>
+[[nodiscard]] OSSIA_INLINE T lowpass_alpha(T cutoff, T dt) noexcept
+{
+  const T r = T(ossia::two_pi) * cutoff * dt;
+  return r / (r + T(1));
+}
+
+/**
+ * @brief Smoothing factor of a first-order lag with a given time constant.
+ *
+ * Equivalent to lowpass_alpha(1 / (2 * pi * tau), dt), spelled in the unit that
+ * is usually more natural when a UI exposes a "smoothing time" instead of a
+ * cutoff.
+ *
+ * @param tau Time constant, in seconds. Must be > 0.
+ * @param dt Time since the previous sample, in seconds. Must be > 0.
+ */
+template <typename T>
+[[nodiscard]] OSSIA_INLINE T lag_alpha(T tau, T dt) noexcept
+{
+  return dt / (dt + tau);
+}
+
+/**
+ * @brief First-order low-pass. The building block for everything below.
+ *
+ * The coefficient is passed per-sample instead of being stored, so that the
+ * same filter can be driven by a varying dt or a varying cutoff without
+ * recomputing any internal state.
+ */
+template <typename T = float>
+struct one_pole_filter
+{
+  using value_type = T;
+
+  //! Last output. Only meaningful once primed.
+  T y{};
+
+  //! False until the first sample went through: the first sample is passed
+  //! along untouched rather than being smoothed from an arbitrary zero.
+  bool primed{};
+
+  //! Forget the history: the next sample restarts the filter.
+  OSSIA_INLINE void reset() noexcept
+  {
+    y = T{};
+    primed = false;
+  }
+
+  //! Restart the filter as if @p x had just been output.
+  OSSIA_INLINE void reset(T x) noexcept
+  {
+    y = x;
+    primed = true;
+  }
+
+  //! No runtime parameters: the coefficient is passed per-sample.
+  OSSIA_INLINE void assign_parameters(const one_pole_filter&) noexcept { }
+
+  /**
+   * @param x Input sample.
+   * @param alpha Smoothing factor in [0, 1], e.g. from lowpass_alpha().
+   */
+  [[nodiscard]] OSSIA_INLINE T operator()(T x, T alpha) noexcept
+  {
+    if(!primed) [[unlikely]]
+    {
+      primed = true;
+      return y = x;
+    }
+
+    // One FMA, versus two multiplies for the alpha * x + (1 - alpha) * y form.
+    return y += alpha * (x - y);
+  }
+};
+
+/**
+ * @brief One-euro filter: a low-pass whose cutoff rises with the speed of the
+ * signal.
+ *
+ * Casiez, Roussel and Vogel, "1 euro filter: a simple speed-based low-pass
+ * filter for noisy input in interactive systems", CHI 2012.
+ *
+ * The point is the jitter/lag tradeoff: at rest the cutoff drops to
+ * @ref min_cutoff and the output is very smooth, while a fast movement raises
+ * the cutoff so the output stays responsive. Per the authors: if lag during
+ * fast motion is the problem, raise @ref beta ; if jitter at rest is the
+ * problem, lower @ref min_cutoff.
+ *
+ * The derivative is taken against the previous *raw* input, as in the reference
+ * implementation.
+ */
+template <typename T = float>
+struct one_euro_filter
+{
+  using value_type = T;
+
+  //! Cutoff at zero speed, in Hz. Lower is smoother, and laggier.
+  T min_cutoff{1};
+
+  //! How much the speed raises the cutoff. 0 degrades to a plain low-pass.
+  T beta{0};
+
+  //! Cutoff of the low-pass applied to the derivative itself, in Hz.
+  T d_cutoff{1};
+
+  //! Smoother for the value.
+  one_pole_filter<T> x_filter{};
+
+  //! Smoother for the derivative.
+  one_pole_filter<T> dx_filter{};
+
+  //! Previous raw input.
+  T x_prev{};
+
+  //! Forget the history: the next sample restarts the filter.
+  OSSIA_INLINE void reset() noexcept
+  {
+    x_filter.reset();
+    dx_filter.reset();
+    x_prev = T{};
+  }
+
+  //! Adopt @p p's tuning, keeping the history.
+  OSSIA_INLINE void assign_parameters(const one_euro_filter& p) noexcept
+  {
+    min_cutoff = p.min_cutoff;
+    beta = p.beta;
+    d_cutoff = p.d_cutoff;
+  }
+
+  /**
+   * @param x Input sample.
+   * @param dt Time since the previous sample, in seconds.
+   *
+   * A dt <= 0 returns the previous output unchanged rather than dividing by
+   * zero, so that a duplicated timestamp cannot poison the state.
+   */
+  [[nodiscard]] OSSIA_INLINE T operator()(T x, T dt) noexcept
+  {
+    if(dt <= T(0)) [[unlikely]]
+      return x_filter.primed ? x_filter.y : x;
+
+    // Shared between both alphas: alpha = (k * cutoff) / (k * cutoff + 1).
+    const T k = T(ossia::two_pi) * dt;
+
+    // First sample: no derivative to speak of.
+    const T dx = x_filter.primed ? (x - x_prev) / dt : T(0);
+    x_prev = x;
+
+    const T kd = k * d_cutoff;
+    const T edx = dx_filter(dx, kd / (kd + T(1)));
+
+    const T cutoff = min_cutoff + beta * std::abs(edx);
+    const T kc = k * cutoff;
+    return x_filter(x, kc / (kc + T(1)));
+  }
+};
+
+/**
+ * @brief Simple moving average over the last @p N samples.
+ *
+ * O(1) per sample: the window sum is kept incrementally instead of being
+ * recomputed. The accumulator is widened to double for float inputs, because a
+ * running sum drifts over a long performance.
+ *
+ * Until @p N samples have been seen the average is taken over what is
+ * available, so the output is usable from the first sample on.
+ */
+template <typename T = float, std::size_t N = 8>
+struct moving_average_filter
+{
+  static_assert(N >= 1, "a moving average needs at least one sample");
+
+  using value_type = T;
+
+  //! Widened so that the incremental sum does not drift.
+  using accumulator_type = std::conditional_t<std::is_same_v<T, float>, double, T>;
+
+  //! Chronological ring of the window contents.
+  std::array<T, N> history{};
+
+  //! Running sum of the first @ref count entries of the window.
+  accumulator_type sum{};
+
+  //! Where the next sample goes in @ref history.
+  std::uint32_t head{};
+
+  //! How many entries of @ref history are valid, saturating at N.
+  std::uint32_t count{};
+
+  //! Forget the history: the next sample restarts the filter.
+  OSSIA_INLINE void reset() noexcept
+  {
+    sum = accumulator_type{};
+    head = 0;
+    count = 0;
+  }
+
+  //! No runtime parameters: the window size is a template argument.
+  OSSIA_INLINE void assign_parameters(const moving_average_filter&) noexcept { }
+
+  [[nodiscard]] OSSIA_INLINE T operator()(T x) noexcept
+  {
+    if(count == N)
+      sum -= history[head];
+    else
+      ++count;
+
+    sum += x;
+    history[head] = x;
+    head = (head + 1 == N) ? 0 : head + 1;
+
+    return T(sum / accumulator_type(count));
+  }
+};
+
+/**
+ * @brief Running median over the last @p N samples.
+ *
+ * Unlike an average, this rejects isolated outliers outright, which is what one
+ * wants against the occasional bogus reading of a sensor or a tracker.
+ *
+ * Kept as a chronological ring plus a sorted copy of the same window: an insert
+ * is a binary search and a small contiguous move, which for the window sizes
+ * this is meant for beats any heap-based scheme by a wide margin.
+ *
+ * @note Feeding a NaN breaks the ordering invariant of the sorted window, and
+ * with it every subsequent output. Filter them out upstream.
+ */
+template <typename T = float, std::size_t N = 5>
+struct median_filter
+{
+  static_assert(N >= 1, "a median needs at least one sample");
+
+  using value_type = T;
+
+  //! Chronological ring of the window contents.
+  std::array<T, N> history{};
+
+  //! The same contents, kept sorted over the first @ref count entries.
+  std::array<T, N> sorted{};
+
+  //! Where the next sample goes in @ref history.
+  std::uint32_t head{};
+
+  //! How many entries are valid, saturating at N.
+  std::uint32_t count{};
+
+  //! Forget the history: the next sample restarts the filter.
+  OSSIA_INLINE void reset() noexcept
+  {
+    head = 0;
+    count = 0;
+  }
+
+  //! No runtime parameters: the window size is a template argument.
+  OSSIA_INLINE void assign_parameters(const median_filter&) noexcept { }
+
+  [[nodiscard]] OSSIA_INLINE T operator()(T x) noexcept
+  {
+    const auto begin = sorted.begin();
+
+    if(count == N)
+    {
+      // Drop the sample falling out of the window, then insert the new one.
+      const auto last = begin + N;
+      const auto old = std::lower_bound(begin, last, history[head]);
+      std::move(old + 1, last, old);
+
+      const auto pos = std::lower_bound(begin, last - 1, x);
+      std::move_backward(pos, last - 1, last);
+      *pos = x;
+    }
+    else
+    {
+      const auto last = begin + count;
+      const auto pos = std::lower_bound(begin, last, x);
+      std::move_backward(pos, last, last + 1);
+      *pos = x;
+      ++count;
+    }
+
+    history[head] = x;
+    head = (head + 1 == N) ? 0 : head + 1;
+
+    const std::uint32_t n = count;
+    if(n & 1u)
+      return sorted[n / 2];
+    return (sorted[n / 2 - 1] + sorted[n / 2]) * T(0.5);
+  }
+};
+
+/**
+ * @brief Applies one independent @p Filter per component of a vector-valued
+ * signal.
+ *
+ * The filters are owned per-component so that, for instance, the x of a tracked
+ * point never bleeds into its y - and, when used per tracked object, so that
+ * one object's history never bleeds into another's.
+ *
+ * @tparam N How many components fit without allocating.
+ */
+template <typename Filter, std::size_t N = 4>
+struct multi_filter
+{
+  using filter_type = Filter;
+  using value_type = typename Filter::value_type;
+
+  //! Copied into every new component. Set the parameters here, then call
+  //! configure() to push them onto the components already in flight.
+  Filter prototype{};
+
+  //! One filter per component.
+  ossia::small_vector<Filter, N> filters{};
+
+  /**
+   * @brief Make sure there are exactly @p n components.
+   *
+   * A change of component count resets the temporal state: there is no
+   * meaningful way to map an old component onto a new one.
+   */
+  OSSIA_INLINE void ensure(std::size_t n)
+  {
+    if(filters.size() != n) [[unlikely]]
+      filters.assign(n, prototype);
+  }
+
+  //! Push the prototype's tuning onto the live filters, keeping their history.
+  OSSIA_INLINE void configure() noexcept
+  {
+    for(auto& f : filters)
+      f.assign_parameters(prototype);
+  }
+
+  //! Forget every component's history, keeping the component count.
+  void reset() noexcept
+  {
+    for(auto& f : filters)
+      f.reset();
+  }
+
+  //! Drop every component.
+  void clear() noexcept { filters.clear(); }
+
+  /**
+   * @brief Filter @p n components in place.
+   *
+   * @param v Components, modified in place.
+   * @param n How many.
+   * @param args Forwarded to each filter, e.g. the dt of a one_euro_filter.
+   */
+  template <typename... Args>
+  OSSIA_INLINE void operator()(value_type* v, std::size_t n, Args... args) noexcept
+  {
+    ensure(n);
+    for(std::size_t i = 0; i < n; i++)
+      v[i] = filters[i](v[i], args...);
+  }
+};
+
+/**
+ * @brief Move @p a onto the branch closest to @p reference.
+ *
+ * Angles wrap, so a naive filter run over them lurches by a full turn every
+ * time the signal crosses the discontinuity. Unwrapping against the previous
+ * value first makes them safe to smooth.
+ *
+ * Branchless, unlike the usual while-loop form.
+ */
+template <typename T>
+[[nodiscard]] OSSIA_INLINE T unwrap_angle(T a, T reference) noexcept
+{
+  // remainder() lands in [-pi, pi] for a divisor of two_pi.
+  return reference + T(ossia::remainder(a - reference, T(ossia::two_pi)));
+}
+
+}

--- a/src/ossia/math/math_expression.cpp
+++ b/src/ossia/math/math_expression.cpp
@@ -249,7 +249,7 @@ struct math_expression::impl
   exprtk::expression<double> expr;
   std::string cur_expr_txt;
   std::optional<std::vector<std::string>> variables;
-  std::vector<std::string> missing_variables;
+  std::string last_error;
   bool valid{};
 
   [[no_unique_address]] bit_binop<std::bit_and<>, double> f_bit_and;
@@ -304,20 +304,45 @@ void math_expression::add_constant(const std::string& var, double& value)
   impl->syms.add_constant(var, value);
 }
 
+// An exprtk::vector_view can be re-pointed and resized at will, but only ever
+// *below* the size it was constructed with: set_size() silently refuses to grow
+// past base_size(). Re-registering a bigger view is not an option either, as
+// symbol_table::remove_vector() deletes a holder that the currently compiled
+// expression still points to.
+//
+// So every view is built against this size and then immediately narrowed to the
+// buffer's real size. base_size() is only ever used to bound set_size(): index
+// checks, both at compile time and at evaluation, go against the current size.
+// Buffers longer than this are seen truncated by the expression.
+static constexpr std::size_t max_vector_view_size = 65536;
+
 void math_expression::add_vector(const std::string& var, std::vector<double>& value)
 {
+  if(value.empty())
+    return;
+
   impl->vector_views.reserve(12);
   auto v = std::make_shared<exprtk::vector_view<double>>(
-      exprtk::make_vector_view(value, value.size()));
+      value.data(), max_vector_view_size);
+  v->set_size(std::min(value.size(), max_vector_view_size));
+
   impl->vector_views[var] = v;
   impl->syms.add_vector(var, *v);
 }
 
 void math_expression::rebase_vector(const std::string& var, std::vector<double>& value)
 {
+  if(value.empty())
+    return;
+
   auto it = impl->vector_views.find(var);
-  assert(it != impl->vector_views.end());
-  it->second->set_size(value.size());
+  if(it == impl->vector_views.end())
+  {
+    add_vector(var, value);
+    return;
+  }
+
+  it->second->set_size(std::min(value.size(), max_vector_view_size));
   it->second->rebase(value.data());
 }
 
@@ -342,33 +367,34 @@ bool math_expression::set_expression(const std::string& expr)
   {
     impl->cur_expr_txt = expr;
     recompile();
-    impl->missing_variables.clear();
   }
 
   return impl->valid;
 }
 
+bool math_expression::valid() const noexcept
+{
+  return impl->valid;
+}
+
 bool math_expression::has_variable(std::string_view var) const noexcept
 {
-  if(std::binary_search(
-         impl->missing_variables.begin(), impl->missing_variables.end(), var))
-    return false;
-
+  // Cheap reject: a variable that does not appear as a substring cannot appear
+  // as a symbol either.
   if(impl->cur_expr_txt.find(var) == std::string::npos)
-  {
-    impl->missing_variables.push_back(std::string(var));
     return false;
-  }
 
-  auto b = impl->expr;
+  // exprtk::collect_variables works on the expression *text*, so this answers
+  // for expressions that failed to compile too - which matters, as the nodes
+  // use it to decide which code path (and thus which vector sizes) to set up.
   if(!impl->variables)
   {
-    if(impl->valid)
-    {
-      impl->variables.emplace();
-      exprtk::collect_variables(impl->cur_expr_txt, *impl->variables);
-    }
+    impl->variables.emplace();
+    if(!exprtk::collect_variables(impl->cur_expr_txt, *impl->variables))
+      return false;
   }
+
+  // collect_variables returns its symbols sorted.
   return std::binary_search(impl->variables->begin(), impl->variables->end(), var);
 }
 
@@ -376,10 +402,24 @@ bool math_expression::recompile()
 {
   impl->variables = std::nullopt;
 
+  // An empty expression is not an error worth logging: it is just a node whose
+  // text field has not been filled in yet.
+  if(impl->cur_expr_txt.empty())
+  {
+    impl->valid = false;
+    impl->last_error.clear();
+    return false;
+  }
+
   impl->valid = g_exprtk_parser.compile(impl->cur_expr_txt, impl->expr);
   if(!impl->valid)
   {
-    ossia::logger().error("Error while parsing: {}", g_exprtk_parser.error());
+    impl->last_error = g_exprtk_parser.error();
+    ossia::logger().error("Error while parsing: {}", impl->last_error);
+  }
+  else
+  {
+    impl->last_error.clear();
   }
 
   return impl->valid;
@@ -387,11 +427,15 @@ bool math_expression::recompile()
 
 std::string math_expression::error() const
 {
-  return g_exprtk_parser.error();
+  return impl->last_error;
 }
 
 double math_expression::value()
 {
+  // On a failed compilation exprtk leaves the previously compiled tree in
+  // place: evaluating it would silently give the *old* expression's result.
+  if(!impl->valid)
+    return std::numeric_limits<double>::quiet_NaN();
   return impl->expr.value();
 }
 
@@ -462,11 +506,21 @@ static ossia::value result_to_value(auto& r)
 
 ossia::value math_expression::result()
 {
-  double v = impl->expr.value();
+  if(!impl->valid)
+    return ossia::value{};
+
+  const double v = impl->expr.value();
   if(!ossia::safe_isnan(v))
     return v;
-  else
-    return ossia::value{result_to_value(impl->expr.results())};
+
+  // exprtk signals "the expression ended with `return [...]`" by evaluating to
+  // NaN *and* filling the results context. An expression that merely computed
+  // a NaN (sqrt(-1), 0/0, ...) leaves it empty and is still a scalar result.
+  auto& results = impl->expr.results();
+  if(results.count() == 0)
+    return v;
+
+  return ossia::value{result_to_value(results)};
 }
 
 }

--- a/src/ossia/math/math_expression.hpp
+++ b/src/ossia/math/math_expression.hpp
@@ -25,7 +25,14 @@ public:
   bool set_expression(const std::string& expr);
   bool recompile();
 
+  //! Whether the current expression compiled successfully.
+  bool valid() const noexcept;
+
+  //! Whether the expression *text* references that variable. This is a lexical
+  //! query: it answers for expressions that did not compile, too.
   bool has_variable(std::string_view var) const noexcept;
+
+  //! The error of the last compilation of this expression; empty if it compiled.
   std::string error() const;
 
   double value();

--- a/src/ossia/math/point_tracker.hpp
+++ b/src/ossia/math/point_tracker.hpp
@@ -1,0 +1,938 @@
+#pragma once
+#include <ossia/detail/config.hpp>
+
+#include <ossia/detail/small_vector.hpp>
+#include <ossia/math/filters.hpp>
+#include <ossia/math/tracking.hpp>
+
+#include <cmath>
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+/**
+ * \file point_tracker.hpp
+ *
+ * Generic multi-object point tracker: turns per-frame sets of bare detections
+ * (positions with an optional confidence) into stable identified tracks over
+ * time. This is the association + filtering + lifecycle layer between a
+ * detector (blobs, keypoints, TUIO/OSC points...) and whatever maps object
+ * identity to sound or visuals.
+ *
+ * Ingredients, and where they come from:
+ *  - per-track constant-velocity Kalman over real elapsed time (tracking.hpp),
+ *  - two-stage association by detection confidence (ByteTrack: low-confidence
+ *    detections may sustain an existing track but never start one),
+ *  - OC-SORT touches: velocity-direction consistency in the cost, velocity
+ *    re-seeding after a gap, and observation-centric re-update along a virtual
+ *    trajectory when a lost track is revived (kills the post-occlusion lurch),
+ *  - M-of-N + minimum-time confirmation, so confirmation latency is stable in
+ *    milliseconds across frame rates instead of being a frame count,
+ *  - two-tier lifecycle: provisional tracks exist (and can be emitted, flagged)
+ *    from the very first detection - waiting for confirmation costs ~100 ms of
+ *    onset latency, an order of magnitude over the ~10 ms budget of musical
+ *    control - while confirmed tracks are the stable set for continuous
+ *    mappings,
+ *  - persistent ids (monotonic, never reused) plus dense reusable slots with a
+ *    quarantine hold, for mapping to a fixed bank of voices/parameters,
+ *  - per-track One-Euro output smoothing (filters.hpp), owned per identity so
+ *    two crossing objects never bleed into each other's history.
+ *
+ * All time is real seconds passed in by the caller; nothing assumes a fixed
+ * frame rate. Coordinates are whatever space the caller uses consistently;
+ * every threshold with a unit (max_speed, meas_std...) is in that same space.
+ *
+ * The hot path does not allocate once the scratch buffers are warm, except when
+ * a new track is born.
+ */
+
+namespace ossia
+{
+
+enum class track_state : std::uint8_t
+{
+  provisional, //!< Seen, but not yet confirmed: usable for triggers, flagged.
+  confirmed,   //!< Passed M-of-N + time confirmation: the stable set.
+  coasting,    //!< Missed recently; position is the Kalman prediction.
+  revived,     //!< Re-acquired after being lost (transient, one frame).
+  lost,        //!< Past the coast window; kept for revival, not emitted.
+  expired      //!< Terminal; the track is removed right after this is set.
+};
+
+enum class track_motion_gate : std::uint8_t
+{
+  off,        //!< No motion gate: nearest-neighbour within the cost ranking.
+  max_speed,  //!< Analytic: displacement <= max_speed * dt * (1 + lost/coast).
+  mahalanobis //!< Kalman gating distance against a chi-square threshold.
+};
+
+enum class track_slot_allocation : std::uint8_t
+{
+  lowest_free,    //!< Lowest free slot index (cv.jit-style, deterministic).
+  round_robin,    //!< Cycle through the slots, spreading reuse over time.
+  nearest_vacated //!< Prefer a recently-vacated slot near the track's position.
+};
+
+enum class track_slot_steal : std::uint8_t
+{
+  never,            //!< A confirmed track without a free slot stays unslotted.
+  stalest,          //!< Steal from the track unseen for the longest time.
+  lowest_confidence //!< Steal from the track with the lowest confidence.
+};
+
+template <std::size_t N>
+struct point_tracker_config
+{
+  // --- Association ---------------------------------------------------------
+  track_motion_gate gate = track_motion_gate::max_speed;
+  //! Maximum plausible object speed, in coordinate units per second. Also sets
+  //! the scale on which association costs are normalized.
+  float max_speed = 2.f;
+  //! Chi-square 99.9% for N degrees of freedom: 13.8155 (2), 16.2662 (3).
+  //! Not the DeepSORT-conventional 95% (5.9915 / 7.8147): the gate's
+  //! false-rejection rate is exactly the chi-square tail, every rejected true
+  //! detection births a competing duplicate track (birth needs only
+  //! new_conf), and a 5%-per-frame rejection rate measured ~200 id switches
+  //! in 20 s at 60 fps on a single isolated object where 0.1% measures 0.
+  //! The tail rate is per FRAME, so a tight quantile also degrades faster at
+  //! higher frame rates.
+  float mahalanobis_thresh = N == 3 ? 16.2662f : 13.8155f;
+  //! ByteTrack: after the high-confidence pass, let low-confidence detections
+  //! sustain still-unmatched recent tracks (worth 1-10 IDF1 points).
+  bool two_stage = true;
+  float high_conf = 0.5f; //!< >= : first-stage detections.
+  float low_conf = 0.1f;  //!< [low, high[ : second-stage recovery detections.
+  float new_conf = 0.6f;  //!< Birth a track only at or above this.
+  //! OC-SORT velocity-direction consistency weight in the association cost.
+  //! The term sums the angle between observed track direction and the
+  //! track->detection direction over temporal baselines of 1, 2 and 3
+  //! detection frames (OC-SORT Table 7: gains stop at 3 and decline at 5).
+  float dir_weight = 0.2f;
+  //! Hybrid-SORT TCM (Tracklet Confidence Modeling, arXiv:2308.00783): weight
+  //! of |predicted track confidence - detection confidence| in the
+  //! association cost. Detection confidence is a strong identity cue exactly
+  //! when position is at its weakest (occlusions depress it smoothly), worth
+  //! +4 HOTA in their ablation. The prediction is Kalman-filtered in the
+  //! high-confidence stage but two-point LINEAR in the low-confidence stage:
+  //! confidence changes abruptly at occlusion onset/exit and the Kalman lags
+  //! those transitions (their ablated Kalman/Linear split, Table IV - linear
+  //! in the first stage is worse than nothing). 0 disables the term.
+  float conf_weight = 1.0f;
+
+  // --- Motion filter -------------------------------------------------------
+  //! Process noise: acceleration magnitude of the tracked motion, units/s^2.
+  //! Human motion peaks around 2 m/s^2; 2/3 fits that as 3 sigma.
+  float accel_sigma = 0.67f;
+  //! Measurement noise std of the detector, in coordinate units.
+  float meas_std = 0.005f;
+
+  // --- Confirmation --------------------------------------------------------
+  //! Minimum age before confirmation, seconds (not frames: milliseconds mean
+  //! the same thing at 30 and at 144 fps).
+  float confirm_time = 0.100f;
+  std::uint32_t confirm_hits = 3;   //!< M of...
+  std::uint32_t confirm_window = 5; //!< ...the last N detection frames.
+  //! A detection at or above this confidence confirms immediately.
+  float instant_confirm = 0.9f;
+
+  // --- Lifecycle -----------------------------------------------------------
+  //! How long a missed track keeps being emitted at its predicted position.
+  float coast_time = 0.5f;
+  bool revive = true;      //!< Keep lost tracks around for re-acquisition.
+  float revive_time = 2.f; //!< Revival window after the coast window, seconds.
+  //! OC-SORT ORU: on revival, re-run the filter along a virtual trajectory
+  //! spanning the gap instead of trusting the drifted prediction.
+  bool revive_reupdate = true;
+
+  // --- Output smoothing (One-Euro, per track per axis) ---------------------
+  bool smooth = true;
+  float min_cutoff = 1.f;   //!< Hz. Lower = smoother at rest.
+  float beta = 1.f;         //!< Speed coefficient. MediaPipe ships 10-80.
+  float deriv_cutoff = 1.f; //!< Hz, low-pass on the derivative estimate.
+
+  // --- Slots ---------------------------------------------------------------
+  std::uint32_t slot_count = 8;
+  track_slot_allocation allocation = track_slot_allocation::lowest_free;
+  track_slot_steal steal = track_slot_steal::never;
+  //! Quarantine: a vacated slot is not reallocated for this long, so a brief
+  //! exit/re-entry does not hand an object's slot to a stranger.
+  float slot_hold_time = 0.25f;
+};
+
+template <std::size_t N>
+struct point_detection
+{
+  std::array<float, N> position{};
+  float confidence = 1.f;
+};
+
+template <std::size_t N>
+struct point_track
+{
+  //! Persistent identity: monotonic, never reused within a tracker lifetime.
+  std::int32_t id = -1;
+  //! Dense reusable index in [0, slot_count[, -1 if unslotted.
+  std::int32_t slot = -1;
+  track_state state = track_state::provisional;
+  //! Seconds (tracker clock) at birth - the true identity; the index in
+  //! tracks() is only a transient handle.
+  double creation_time = 0.;
+  float age = 0.f;             //!< Seconds since birth.
+  float time_since_seen = 0.f; //!< Seconds since the last matched detection.
+  float confidence = 0.f;      //!< Confidence of the last matched detection.
+  bool reacquired = false;     //!< Went through at least one lost->revived.
+
+  //! Kalman state: position/velocity per axis, velocity in units/second.
+  kalman_point_filter<N> kf{};
+  //! Filter state as of the last measurement, for the revival re-update.
+  kalman_point_filter<N> kf_at_meas{};
+  //! One-Euro smoothed output position.
+  std::array<float, N> filtered{};
+  //! Last raw measurement.
+  std::array<float, N> last_meas{};
+  //! Ring of the most recent observed (matched) positions: obs_hist[0]
+  //! duplicates last_meas, obs_hist[k] is k detection-frames earlier. Feeds
+  //! the multi-dt direction-consistency term.
+  std::array<std::array<float, N>, 4> obs_hist{};
+  std::uint8_t obs_count = 0;
+  //! Kalman state over the detection confidence (Hybrid-SORT TCM):
+  //! p = confidence, v = confidence rate per second.
+  kalman_pv_filter conf_kf{};
+  //! Confidence of the match before last (c[t-2]); -1 while there is none.
+  //! With `confidence` (c[t-1]) this is the two-point linear extrapolation
+  //! base for the low-confidence association stage.
+  float conf_prev = -1.f;
+
+  std::array<one_euro_filter<float>, N> smoothers{};
+
+  //! Ring of the last detection-frame outcomes, bit 0 = most recent frame.
+  std::uint32_t hit_history = 0;
+  std::uint32_t hits = 0; //!< Total matched detections.
+  std::uint32_t consecutive_misses = 0;
+
+  [[nodiscard]] std::array<float, N> position() const noexcept { return kf.position(); }
+  [[nodiscard]] std::array<float, N> velocity() const noexcept { return kf.velocity(); }
+
+  //! Should this track appear in the outputs?
+  [[nodiscard]] bool emitted(bool include_provisional) const noexcept
+  {
+    switch(state)
+    {
+      case track_state::confirmed:
+      case track_state::coasting:
+      case track_state::revived:
+        return true;
+      case track_state::provisional:
+        return include_provisional;
+      default:
+        return false;
+    }
+  }
+};
+
+/**
+ * @brief Lifecycle notifications of one step. Ids, not indices: by the time an
+ * exit is reported the track is no longer in tracks().
+ */
+struct track_events
+{
+  ossia::small_vector<std::int32_t, 8> entered;
+  ossia::small_vector<std::int32_t, 8> confirmed;
+  ossia::small_vector<std::int32_t, 8> exited;
+  ossia::small_vector<std::int32_t, 8> revived;
+
+  void clear() noexcept
+  {
+    entered.clear();
+    confirmed.clear();
+    exited.clear();
+    revived.clear();
+  }
+};
+
+template <std::size_t N>
+class point_tracker
+{
+public:
+  using config = point_tracker_config<N>;
+  using detection = point_detection<N>;
+  using track = point_track<N>;
+
+  void configure(const config& c)
+  {
+    m_cfg = c;
+    m_proto.min_cutoff = c.min_cutoff;
+    m_proto.beta = c.beta;
+    m_proto.d_cutoff = c.deriv_cutoff;
+    for(auto& t : m_tracks)
+    {
+      for(auto& s : t.smoothers)
+        s.assign_parameters(m_proto);
+      // A slot beyond a shrunk slot count is gone; no quarantine for those.
+      if(t.slot >= std::int32_t(c.slot_count))
+        t.slot = -1;
+    }
+    m_vacated.erase(
+        std::remove_if(
+            m_vacated.begin(), m_vacated.end(),
+            [&](const vacated& v) { return v.slot >= std::int32_t(c.slot_count); }),
+        m_vacated.end());
+  }
+
+  const config& get_config() const noexcept { return m_cfg; }
+  const std::vector<track>& tracks() const noexcept { return m_tracks; }
+  const track_events& events() const noexcept { return m_events; }
+  double now() const noexcept { return m_now; }
+  //! Smoothed estimate of the spacing between detection frames, seconds.
+  float estimated_period() const noexcept { return m_est_period; }
+
+  //! Forget everything, including the id counter.
+  void reset()
+  {
+    m_tracks.clear();
+    m_vacated.clear();
+    m_events.clear();
+    m_next_id = 1;
+    m_now = 0.;
+    m_last_frame_time = 0.;
+    m_est_period = 1.f / 30.f;
+    m_rr_cursor = 0;
+  }
+
+  /**
+   * @brief Let @p dt seconds pass without a detection frame.
+   *
+   * Predicts every track forward, applies the time-based lifecycle transitions
+   * (coasting -> lost -> expired) and fires the corresponding events. Call this
+   * when time passes but the source produced nothing, so tracks keep coasting
+   * and eventually expire even if the detector goes silent.
+   */
+  void advance(float dt)
+  {
+    m_events.clear();
+    step_time(dt);
+    refresh_states_and_expire();
+    smooth_outputs(dt);
+  }
+
+  /**
+   * @brief Process one detection frame, @p dt seconds after the previous call.
+   *
+   * @return One entry per input detection: the id of the track it was
+   * associated to (freshly born included), or -1 if it was dropped. Valid until
+   * the next update()/advance().
+   */
+  const std::vector<std::int32_t>& update(const detection* dets, std::size_t n, float dt)
+  {
+    m_events.clear();
+    step_time(dt);
+
+    // Real spacing between detection frames (advance() may have run inbetween).
+    const float frame_dt = std::clamp(float(m_now - m_last_frame_time), 1e-4f, 10.f);
+    m_last_frame_time = m_now;
+    m_est_period = 0.9f * m_est_period + 0.1f * std::min(frame_dt, 1.f);
+
+    auto& out = m_assign;
+    out.assign(n, -1);
+
+    // Split by confidence (ByteTrack)
+    m_high.clear();
+    m_low.clear();
+    for(std::size_t i = 0; i < n; i++)
+    {
+      const float c = dets[i].confidence;
+      if(c >= m_cfg.high_conf)
+        m_high.push_back(std::int32_t(i));
+      else if(m_cfg.two_stage && c >= m_cfg.low_conf)
+        m_low.push_back(std::int32_t(i));
+    }
+
+    m_t_match.assign(m_tracks.size(), -1);
+    m_d_used.assign(n, 0);
+
+    // Stage 1: all tracks (lost ones included when revival is on) vs
+    // high-confidence detections.
+    m_cands.clear();
+    for(std::size_t ti = 0; ti < m_tracks.size(); ti++)
+    {
+      const auto& t = m_tracks[ti];
+      if(t.state == track_state::lost && !m_cfg.revive)
+        continue;
+      for(const auto di : m_high)
+      {
+        float c;
+        if(admissible(t, dets[di], frame_dt, true, c))
+          m_cands.push_back({c, std::int32_t(ti), di});
+      }
+    }
+    greedy_assignment(m_cands, m_t_match.data(), m_tracks.size(), m_d_used.data(), n);
+
+    // Stage 2: still-unmatched recent tracks vs low-confidence detections.
+    // Lost tracks are excluded: a low-confidence blip must not revive.
+    if(!m_low.empty())
+    {
+      m_cands.clear();
+      for(std::size_t ti = 0; ti < m_tracks.size(); ti++)
+      {
+        if(m_t_match[ti] >= 0)
+          continue;
+        const auto& t = m_tracks[ti];
+        if(t.state == track_state::lost)
+          continue;
+        for(const auto di : m_low)
+        {
+          float c;
+          if(admissible(t, dets[di], frame_dt, false, c))
+            m_cands.push_back({c, std::int32_t(ti), di});
+        }
+      }
+      greedy_assignment(m_cands, m_t_match.data(), m_tracks.size(), m_d_used.data(), n);
+    }
+
+    // Apply matches / misses.
+    for(std::size_t ti = 0; ti < m_tracks.size(); ti++)
+    {
+      auto& t = m_tracks[ti];
+      const auto di = m_t_match[ti];
+      if(di >= 0)
+      {
+        apply_match(t, dets[di]);
+        out[di] = t.id;
+      }
+      else
+      {
+        t.hit_history <<= 1;
+        t.consecutive_misses++;
+      }
+    }
+
+    // Births: unmatched detections above the birth threshold.
+    for(std::size_t i = 0; i < n; i++)
+    {
+      if(m_d_used[i] || dets[i].confidence < m_cfg.new_conf)
+        continue;
+      out[i] = birth(dets[i]);
+    }
+
+    refresh_states_and_expire();
+    smooth_outputs(dt);
+    return out;
+  }
+
+  //! update() convenience over a vector.
+  const std::vector<std::int32_t>& update(const std::vector<detection>& dets, float dt)
+  {
+    return update(dets.data(), dets.size(), dt);
+  }
+
+private:
+  // TCM internals. Not exposed: conf_weight is the tunable; these only shape
+  // how fast the per-track confidence estimate adapts. Confidence lives in
+  // [0,1] and detector jitter on it is typically a few percent.
+  static constexpr float conf_sigma_a = 2.f;    // confidence units / s^2
+  static constexpr float conf_meas_std = 0.05f; // confidence jitter std
+
+  struct vacated
+  {
+    std::int32_t slot;
+    std::array<float, N> position;
+    double time;
+  };
+
+  static float
+  distance(const std::array<float, N>& a, const std::array<float, N>& b) noexcept
+  {
+    float d2 = 0.f;
+    for(std::size_t i = 0; i < N; i++)
+    {
+      const float d = a[i] - b[i];
+      d2 += d * d;
+    }
+    return std::sqrt(d2);
+  }
+
+  void step_time(float dt)
+  {
+    if(dt < 0.f)
+      dt = 0.f;
+    m_now += dt;
+    if(dt > 0.f)
+    {
+      const auto qc = kalman_pv_filter::cwna(conf_sigma_a, dt);
+      for(auto& t : m_tracks)
+      {
+        t.kf.predict(dt, m_cfg.accel_sigma);
+        t.conf_kf.predict(dt, qc);
+        t.age += dt;
+        t.time_since_seen += dt;
+      }
+    }
+  }
+
+  //! Association gate + cost. Returns false if the pair is implausible.
+  //! @p high_stage selects the TCM confidence predictor (Kalman for the
+  //! high-confidence stage, two-point linear for the low-confidence one).
+  bool admissible(
+      const track& t, const detection& d, float frame_dt, bool high_stage,
+      float& cost) const noexcept
+  {
+    const auto pred = t.kf.position();
+    const float dist = distance(pred, d.position);
+
+    // The gate the config documents: one frame's travel budget, widened
+    // sub-linearly with how long the track has been unseen.
+    //
+    // The measurement-noise allowance is not optional. `dist` compares a
+    // predicted position against a *noisy* measurement, so it is on the order
+    // of meas_std even for a perfectly tracked, perfectly stationary object.
+    // Without the term, any detector whose noise approaches max_speed * dt
+    // (0.033 units at 2 units/s and 60 fps) has its own detections gated out:
+    // the track then coasts, dies and is reborn with a new id, several hundred
+    // times a minute, with nothing else in the scene to confuse it with.
+    // The revive gate below already carries the same allowance.
+    const float coast = std::max(m_cfg.coast_time, 1e-3f);
+    const float gate_r = std::max(
+        m_cfg.max_speed * frame_dt * (1.f + t.time_since_seen / coast)
+            + 3.f * m_cfg.meas_std,
+        1e-6f);
+
+    switch(m_cfg.gate)
+    {
+      case track_motion_gate::off:
+        break;
+      case track_motion_gate::max_speed:
+        if(dist > gate_r)
+          return false;
+        break;
+      case track_motion_gate::mahalanobis:
+        // Covariance growth over missed frames widens this gate naturally.
+        if(t.kf.gating_distance2(d.position, m_cfg.meas_std * m_cfg.meas_std)
+           > m_cfg.mahalanobis_thresh)
+          return false;
+        break;
+    }
+
+    cost = dist / gate_r;
+
+    // OC-SORT direction consistency, multi-dt (OC-SORT sec. 3.2 + Table 7):
+    // prefer the detection that continues the track's OBSERVED motion,
+    // summing the angle term over temporal baselines of 1, 2 and 3 detection
+    // frames. A single-frame direction is dominated by measurement noise; a
+    // longer baseline averages it out (their gains stop at dt=3 and decline
+    // at dt=5, so we stop at 3). Observed displacements, not the Kalman
+    // velocity: the Kalman estimate is effectively a dt~1 quantity, and the
+    // real variable here is the temporal baseline.
+    if(m_cfg.dir_weight > 0.f && t.obs_count >= 2)
+    {
+      const int max_dt = std::min<int>(3, t.obs_count - 1);
+      float dir_cost = 0.f;
+      int dir_terms = 0;
+      for(int k = 1; k <= max_dt; k++)
+      {
+        // v: track displacement over the last k observation frames.
+        // w: displacement from the observation k frames before the candidate
+        //    to the candidate detection (the same k-frame span, one frame on).
+        const auto& h0 = t.obs_hist[0];
+        const auto& hv = t.obs_hist[std::size_t(k)];
+        const auto& hw = t.obs_hist[std::size_t(k - 1)];
+        float nv = 0.f, nw = 0.f, dot = 0.f;
+        for(std::size_t i = 0; i < N; i++)
+        {
+          const float v = h0[i] - hv[i];
+          const float w = d.position[i] - hw[i];
+          nv += v * v;
+          nw += w * w;
+          dot += v * w;
+        }
+        if(nv > 1e-8f && nw > 1e-8f)
+        {
+          const float cosang
+              = std::clamp(dot / (std::sqrt(nv) * std::sqrt(nw)), -1.f, 1.f);
+          dir_cost += std::acos(cosang) / 3.14159265f;
+          dir_terms++;
+        }
+      }
+      // Averaged over the available baselines so the term keeps the [0,1]
+      // scale (and the 0.2 default weight) of the single-dt original;
+      // measured: the raw sum triples the penalty on true matches whose
+      // one-frame direction is noise, and costs id switches under clutter.
+      if(dir_terms > 0)
+        cost += m_cfg.dir_weight * (dir_cost / float(dir_terms));
+    }
+
+    // Hybrid-SORT TCM: a track's detection confidence trends smoothly (it
+    // sinks as an occluder approaches, rises on exit), so the predicted
+    // confidence discriminates between tracks exactly when their positions
+    // are entangled. Kalman prediction in the high-confidence stage; in the
+    // low-confidence stage a two-point linear extrapolation instead, because
+    // confidence jumps at occlusion boundaries and the Kalman lags there.
+    if(m_cfg.conf_weight > 0.f)
+    {
+      float chat;
+      if(high_stage)
+        chat = t.conf_kf.p;
+      else if(t.conf_prev >= 0.f)
+        chat = t.confidence + (t.confidence - t.conf_prev);
+      else
+        chat = t.confidence;
+      chat = std::clamp(chat, 0.f, 1.f);
+      cost += m_cfg.conf_weight * std::abs(chat - d.confidence);
+    }
+    return true;
+  }
+
+  void apply_match(track& t, const detection& d)
+  {
+    const float r = std::max(m_cfg.meas_std * m_cfg.meas_std, 1e-12f);
+    const float gap = t.time_since_seen;
+    const bool was_lost = t.state == track_state::lost;
+
+    if(was_lost && m_cfg.revive_reupdate && t.hits > 0)
+    {
+      // OC-SORT ORU: restore the filter to its state at the last measurement
+      // and re-run it along a straight virtual trajectory across the gap, so
+      // the revived track carries a sane velocity instead of lurching from the
+      // coasted prediction to the new position.
+      t.kf = t.kf_at_meas;
+      const int steps
+          = std::clamp(int(std::lround(gap / std::max(m_est_period, 1e-3f))), 1, 32);
+      const float step_dt = gap / float(steps);
+      for(int k = 1; k <= steps; k++)
+      {
+        const float a = float(k) / float(steps);
+        std::array<float, N> z;
+        for(std::size_t i = 0; i < N; i++)
+          z[i] = t.last_meas[i] + a * (d.position[i] - t.last_meas[i]);
+        t.kf.predict(step_dt, m_cfg.accel_sigma);
+        t.kf.update(z, r);
+      }
+    }
+    else
+    {
+      t.kf.update(d.position, r);
+      // Velocity re-seed after a shorter gap: the observation-implied velocity
+      // beats the drifted one.
+      if(gap > 2.f * m_est_period && gap > 1e-4f && t.hits > 0)
+      {
+        std::array<float, N> v;
+        for(std::size_t i = 0; i < N; i++)
+          v[i] = (d.position[i] - t.last_meas[i]) / gap;
+        t.kf.set_velocity(v);
+      }
+    }
+
+    t.hit_history = (t.hit_history << 1) | 1u;
+    t.hits++;
+    t.consecutive_misses = 0;
+    t.time_since_seen = 0.f;
+    t.conf_prev = t.confidence; // c[t-2] for the linear TCM extrapolation
+    t.confidence = d.confidence;
+    t.conf_kf.update(d.confidence, conf_meas_std * conf_meas_std);
+    // Push into the observed-position ring (obs_hist[0] tracks last_meas).
+    for(std::size_t k = t.obs_hist.size() - 1; k > 0; k--)
+      t.obs_hist[k] = t.obs_hist[k - 1];
+    t.obs_hist[0] = d.position;
+    if(t.obs_count < t.obs_hist.size())
+      t.obs_count++;
+    t.last_meas = d.position;
+    t.kf_at_meas = t.kf;
+
+    switch(t.state)
+    {
+      case track_state::provisional: {
+        const auto window_mask
+            = m_cfg.confirm_window >= 32 ? ~0u : ((1u << m_cfg.confirm_window) - 1u);
+        const auto window_hits = std::popcount(t.hit_history & window_mask);
+        if(d.confidence >= m_cfg.instant_confirm
+           || (t.age >= m_cfg.confirm_time && window_hits >= int(m_cfg.confirm_hits)))
+        {
+          t.state = track_state::confirmed;
+          m_events.confirmed.push_back(t.id);
+          allocate_slot(t);
+        }
+        break;
+      }
+      case track_state::lost:
+        t.state = track_state::revived;
+        t.reacquired = true;
+        m_events.revived.push_back(t.id);
+        break;
+      case track_state::coasting:
+      case track_state::revived:
+        t.state = track_state::confirmed;
+        break;
+      default:
+        break;
+    }
+  }
+
+  std::int32_t birth(const detection& d)
+  {
+    track t;
+    t.id = m_next_id++;
+    t.creation_time = m_now;
+    t.confidence = d.confidence;
+    t.last_meas = d.position;
+    t.hit_history = 1;
+    t.hits = 1;
+    // Initial uncertainty: position at measurement noise, velocity wide open
+    // (up to max_speed, 1 sigma at half of it).
+    const float vp = std::max(m_cfg.meas_std * m_cfg.meas_std, 1e-12f);
+    const float sv = 0.5f * std::max(m_cfg.max_speed, 1e-3f);
+    t.kf.initiate(d.position, vp, sv * sv);
+    t.kf_at_meas = t.kf;
+    // TCM confidence filter: position at the detector's confidence jitter,
+    // rate wide open enough to latch onto an occlusion ramp quickly.
+    t.conf_kf.initiate(
+        d.confidence, conf_meas_std * conf_meas_std, conf_sigma_a * conf_sigma_a);
+    t.obs_hist[0] = d.position;
+    t.obs_count = 1;
+    t.filtered = d.position;
+    for(auto& s : t.smoothers)
+      s.assign_parameters(m_proto);
+    m_events.entered.push_back(t.id);
+    if(d.confidence >= m_cfg.instant_confirm)
+    {
+      t.state = track_state::confirmed;
+      m_events.confirmed.push_back(t.id);
+      allocate_slot(t);
+    }
+    m_tracks.push_back(std::move(t));
+    return m_tracks.back().id;
+  }
+
+  void refresh_states_and_expire()
+  {
+    // Missed-frame transitions are time-based so that they also happen when the
+    // detector goes silent and only advance() is being called.
+    const float missed = 1.5f * m_est_period;
+    for(auto& t : m_tracks)
+    {
+      switch(t.state)
+      {
+        case track_state::confirmed:
+        case track_state::revived:
+          if(t.time_since_seen > missed)
+            t.state = track_state::coasting;
+          break;
+        case track_state::coasting:
+          if(t.time_since_seen > m_cfg.coast_time)
+            t.state = m_cfg.revive ? track_state::lost : track_state::expired;
+          break;
+        case track_state::lost:
+          if(t.time_since_seen > m_cfg.coast_time + m_cfg.revive_time)
+            t.state = track_state::expired;
+          break;
+        case track_state::provisional:
+          // A tentative track may only miss as many consecutive frames as the
+          // M-of-N window allows; it also dies with the coast window.
+          if(t.consecutive_misses > m_cfg.confirm_window - m_cfg.confirm_hits
+             || t.time_since_seen > m_cfg.coast_time)
+            t.state = track_state::expired;
+          break;
+        default:
+          break;
+      }
+    }
+
+    // Exactly-once exit: the event fires here and the track is removed in the
+    // same sweep, so it can never be reported dead twice.
+    m_tracks.erase(
+        std::remove_if(
+            m_tracks.begin(), m_tracks.end(),
+            [&](track& t) {
+      if(t.state != track_state::expired)
+        return false;
+      free_slot(t);
+      m_events.exited.push_back(t.id);
+      return true;
+    }),
+        m_tracks.end());
+
+    // Confirmed tracks left unslotted (quarantine, or a full bank) retry as
+    // slots free up - without stealing, so one slot cannot ping-pong between
+    // two tracks.
+    for(auto& t : m_tracks)
+      if(t.slot < 0 && t.emitted(false))
+        allocate_slot(t, false);
+  }
+
+  void smooth_outputs(float dt)
+  {
+    for(auto& t : m_tracks)
+    {
+      const auto p = t.kf.position();
+      if(m_cfg.smooth)
+      {
+        for(std::size_t i = 0; i < N; i++)
+          t.filtered[i] = t.smoothers[i](p[i], dt);
+      }
+      else
+      {
+        t.filtered = p;
+      }
+    }
+  }
+
+  // --- Slots ---------------------------------------------------------------
+
+  bool slot_occupied(std::int32_t s) const noexcept
+  {
+    for(const auto& t : m_tracks)
+      if(t.slot == s)
+        return true;
+    return false;
+  }
+
+  bool slot_quarantined(std::int32_t s) const noexcept
+  {
+    for(const auto& v : m_vacated)
+      if(v.slot == s)
+        return true;
+    return false;
+  }
+
+  void purge_vacated()
+  {
+    m_vacated.erase(
+        std::remove_if(
+            m_vacated.begin(), m_vacated.end(),
+            [&](const vacated& v) { return m_now - v.time > m_cfg.slot_hold_time; }),
+        m_vacated.end());
+  }
+
+  void take_vacated(std::int32_t s)
+  {
+    m_vacated.erase(
+        std::remove_if(
+            m_vacated.begin(), m_vacated.end(),
+            [&](const vacated& v) { return v.slot == s; }),
+        m_vacated.end());
+  }
+
+  void allocate_slot(track& t, bool allow_steal = true)
+  {
+    const auto count = std::int32_t(m_cfg.slot_count);
+    if(count <= 0 || t.slot >= 0)
+      return;
+    purge_vacated();
+
+    // A track re-entering near a spot something recently left is, more often
+    // than not, the same physical object: give it the vacated slot back.
+    if(m_cfg.allocation == track_slot_allocation::nearest_vacated && !m_vacated.empty())
+    {
+      const auto pos = t.kf.position();
+      float best = std::numeric_limits<float>::max();
+      std::int32_t best_slot = -1;
+      for(const auto& v : m_vacated)
+      {
+        const float radius
+            = m_cfg.max_speed * float(m_now - v.time) + 10.f * m_cfg.meas_std;
+        const float d = distance(pos, v.position);
+        if(d <= radius && d < best && !slot_occupied(v.slot))
+        {
+          best = d;
+          best_slot = v.slot;
+        }
+      }
+      if(best_slot >= 0)
+      {
+        take_vacated(best_slot);
+        t.slot = best_slot;
+        return;
+      }
+    }
+
+    // Free and not quarantined, in the policy's order.
+    const auto try_range = [&](bool allow_quarantined) -> std::int32_t {
+      if(m_cfg.allocation == track_slot_allocation::round_robin)
+      {
+        for(std::int32_t k = 0; k < count; k++)
+        {
+          const std::int32_t s = (m_rr_cursor + k) % count;
+          if(!slot_occupied(s) && (allow_quarantined || !slot_quarantined(s)))
+          {
+            m_rr_cursor = (s + 1) % count;
+            return s;
+          }
+        }
+      }
+      else
+      {
+        for(std::int32_t s = 0; s < count; s++)
+          if(!slot_occupied(s) && (allow_quarantined || !slot_quarantined(s)))
+            return s;
+      }
+      return -1;
+    };
+
+    // Quarantined slots are strictly held back: an unslotted track retries
+    // every step (see refresh_states_and_expire), so it picks the slot up as
+    // soon as the hold lapses.
+    const std::int32_t s = try_range(false);
+    if(s >= 0)
+    {
+      take_vacated(s);
+      t.slot = s;
+      return;
+    }
+
+    // All slots owned: steal, if the policy allows. Only at confirmation time -
+    // a retry must not steal, or two tracks would trade one slot forever.
+    if(!allow_steal || m_cfg.steal == track_slot_steal::never)
+      return;
+    track* victim = nullptr;
+    for(auto& o : m_tracks)
+    {
+      if(o.slot < 0 || &o == &t)
+        continue;
+      if(!victim)
+      {
+        victim = &o;
+        continue;
+      }
+      const bool better = m_cfg.steal == track_slot_steal::stalest
+                              ? o.time_since_seen > victim->time_since_seen
+                              : o.confidence < victim->confidence;
+      if(better)
+        victim = &o;
+    }
+    if(victim)
+    {
+      t.slot = victim->slot;
+      victim->slot = -1;
+    }
+  }
+
+  void free_slot(track& t)
+  {
+    if(t.slot < 0)
+      return;
+    m_vacated.push_back({t.slot, t.kf.position(), m_now});
+    t.slot = -1;
+  }
+
+  config m_cfg{};
+  one_euro_filter<float> m_proto{};
+  std::vector<track> m_tracks;
+  std::int32_t m_next_id = 1;
+  double m_now = 0.;
+  double m_last_frame_time = 0.;
+  float m_est_period = 1.f / 30.f;
+  std::int32_t m_rr_cursor = 0;
+
+  track_events m_events;
+  ossia::small_vector<vacated, 8> m_vacated;
+
+  // Per-frame scratch, reused so the hot path does not allocate once warm.
+  std::vector<std::int32_t> m_assign;
+  std::vector<std::int32_t> m_high, m_low, m_t_match;
+  std::vector<char> m_d_used;
+  std::vector<match_candidate> m_cands;
+};
+
+}

--- a/src/ossia/math/safe_math.hpp
+++ b/src/ossia/math/safe_math.hpp
@@ -32,6 +32,34 @@ OSSIA_INLINE bool safe_isnan(double val) noexcept
 #endif
 }
 
+OSSIA_INLINE bool safe_isfinite(double val) noexcept
+{
+#if __FINITE_MATH_ONLY__
+#if defined(_MSC_VER)
+  return std::isfinite(val);
+#elif defined(__APPLE__)
+  return __isfinited(val);
+#elif defined(__EMSCRIPTEN__)
+  const auto cls = __fpclassifyl(val);
+  return cls != FP_NAN && cls != FP_INFINITE;
+#else
+  // On gcc / clang, with -ffast-math, std::isfinite always returns 1.
+  // NaN and infinity are exactly the values whose exponent field is all ones
+  // and nothing else is, so unlike the two predicates above this needs only
+  // one test and does not have to look at the mantissa at all.
+  union
+  {
+    double fp;
+    uint64_t bits;
+  } num{.fp = val};
+
+  return ((unsigned)(num.bits >> 32) & 0x7ff00000) != 0x7ff00000;
+#endif
+#else
+  return std::isfinite(val);
+#endif
+}
+
 OSSIA_INLINE bool safe_isinf(double val) noexcept
 {
 #if __FINITE_MATH_ONLY__

--- a/src/ossia/math/tracking.hpp
+++ b/src/ossia/math/tracking.hpp
@@ -1,0 +1,249 @@
+#pragma once
+#include <ossia/detail/config.hpp>
+
+#include <cmath>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <vector>
+
+/**
+ * \file tracking.hpp
+ *
+ * Building blocks for multi-object trackers: a dt-correct scalar
+ * position-velocity Kalman filter, its N-dimensional composition, and the
+ * greedy bipartite assignment step shared by the trackers in the tree.
+ *
+ * A constant-velocity tracker with independent axes, a diagonal measurement
+ * noise and a (block-)diagonal process noise decouples exactly into one
+ * two-state filter per axis: the full 2Nx2N filter (ByteTrack's 8-dim xyah
+ * included) is mathematically identical to N of these, so no matrix library is
+ * needed and everything below is closed-form scalar algebra.
+ *
+ * Everything takes an explicit dt in seconds: these run off cameras, OSC and
+ * TUIO sources whose frame spacing is neither fixed nor known in advance.
+ */
+
+namespace ossia
+{
+
+/**
+ * @brief Scalar constant-velocity Kalman filter, one axis of a tracked point.
+ *
+ * State is [position, velocity]; the measurement is the position alone.
+ * Velocity is in units per second.
+ */
+struct kalman_pv_filter
+{
+  //! Discrete process noise covariance for one predict step.
+  struct process_noise
+  {
+    float q00, q01, q11;
+  };
+
+  /**
+   * @brief Discretised continuous-white-noise-acceleration process noise.
+   *
+   * Q = q * [[dt^3/3, dt^2/2], [dt^2/2, dt]], with q = sigma_a^2.
+   *
+   * @param sigma_a Acceleration magnitude of the tracked motion. Human motion
+   *        peaks around 2 m/s^2; fitting that as 3 sigma gives ~0.67 as a
+   *        default in metric spaces. (Strictly q is a power spectral density in
+   *        units^2/s^3; treating sigma_a^2 as its value is the usual shortcut.)
+   * @param dt Time step in seconds.
+   */
+  [[nodiscard]] static OSSIA_INLINE process_noise cwna(float sigma_a, float dt) noexcept
+  {
+    const float q = sigma_a * sigma_a;
+    const float dt2 = dt * dt;
+    return {q * dt2 * dt / 3.f, q * dt2 / 2.f, q * dt};
+  }
+
+  /**
+   * @brief Ad-hoc diagonal process noise, dt-scaled.
+   *
+   * For filters tuned with per-frame standard deviations (ByteTrack's
+   * std_weight_position / std_weight_velocity): pass the per-second equivalents
+   * and the reference-relative time ratio; reproduces the historical diagonal
+   * exactly at the reference rate while still growing with elapsed time.
+   *
+   * @param std_p Position process std for one reference-length step.
+   * @param std_v Velocity process std for one reference-length step.
+   * @param time_ratio dt / reference_dt.
+   */
+  [[nodiscard]] static OSSIA_INLINE process_noise
+  diagonal(float std_p, float std_v, float time_ratio) noexcept
+  {
+    return {std_p * std_p * time_ratio, 0.f, std_v * std_v * time_ratio};
+  }
+
+  //! State: position and velocity (units, units/s).
+  float p{}, v{};
+
+  //! Covariance, symmetric 2x2: [[P00, P01], [P01, P11]].
+  float P00{}, P01{}, P11{};
+
+  //! Start tracking at @p p0 with the given initial variances.
+  OSSIA_INLINE void initiate(float p0, float var_p, float var_v) noexcept
+  {
+    p = p0;
+    v = 0.f;
+    P00 = var_p;
+    P01 = 0.f;
+    P11 = var_v;
+  }
+
+  //! Propagate the state @p dt seconds forward.
+  OSSIA_INLINE void predict(float dt, const process_noise& q) noexcept
+  {
+    p += v * dt;
+    P00 += dt * (2.f * P01 + dt * P11) + q.q00;
+    P01 += dt * P11 + q.q01;
+    P11 += q.q11;
+  }
+
+  /**
+   * @brief Fold in a position measurement.
+   * @param z Measured position.
+   * @param r Measurement variance (std^2).
+   */
+  OSSIA_INLINE void update(float z, float r) noexcept
+  {
+    const float S = P00 + r;
+    if(!(S > 0.f)) [[unlikely]]
+      return; // degenerate (or NaN) innovation covariance: skip the update
+    const float K0 = P00 / S;
+    const float K1 = P01 / S;
+    const float y = z - p;
+    p += K0 * y;
+    v += K1 * y;
+    P01 -= K0 * P01;
+    P11 -= K1 * P01; // uses the already-updated P01 = (1-K0)P01: exact (I-KH)P
+    P00 -= K0 * P00;
+  }
+
+  //! Squared Mahalanobis distance of measurement @p z, in measurement space.
+  //! Chi-square distributed with 1 DOF; sum over axes for N DOF.
+  [[nodiscard]] OSSIA_INLINE float gating_distance2(float z, float r) const noexcept
+  {
+    const float S = P00 + r;
+    const float y = z - p;
+    return S > 0.f ? (y * y) / S : 0.f;
+  }
+};
+
+/**
+ * @brief N independent position-velocity Kalman filters: a tracked N-D point.
+ *
+ * [pos, vel] state per axis (so 4 states in 2D, 6 in 3D), isotropic noise.
+ */
+template <std::size_t N>
+struct kalman_point_filter
+{
+  std::array<kalman_pv_filter, N> axes{};
+
+  OSSIA_INLINE void
+  initiate(const std::array<float, N>& p0, float var_p, float var_v) noexcept
+  {
+    for(std::size_t i = 0; i < N; i++)
+      axes[i].initiate(p0[i], var_p, var_v);
+  }
+
+  //! Propagate @p dt seconds forward with acceleration noise @p sigma_a.
+  OSSIA_INLINE void predict(float dt, float sigma_a) noexcept
+  {
+    const auto q = kalman_pv_filter::cwna(sigma_a, dt);
+    for(auto& a : axes)
+      a.predict(dt, q);
+  }
+
+  //! Fold in a position measurement with isotropic variance @p r.
+  OSSIA_INLINE void update(const std::array<float, N>& z, float r) noexcept
+  {
+    for(std::size_t i = 0; i < N; i++)
+      axes[i].update(z[i], r);
+  }
+
+  //! Squared Mahalanobis distance, chi-square with N DOF.
+  [[nodiscard]] OSSIA_INLINE float
+  gating_distance2(const std::array<float, N>& z, float r) const noexcept
+  {
+    float d = 0.f;
+    for(std::size_t i = 0; i < N; i++)
+      d += axes[i].gating_distance2(z[i], r);
+    return d;
+  }
+
+  [[nodiscard]] OSSIA_INLINE std::array<float, N> position() const noexcept
+  {
+    std::array<float, N> r;
+    for(std::size_t i = 0; i < N; i++)
+      r[i] = axes[i].p;
+    return r;
+  }
+
+  [[nodiscard]] OSSIA_INLINE std::array<float, N> velocity() const noexcept
+  {
+    std::array<float, N> r;
+    for(std::size_t i = 0; i < N; i++)
+      r[i] = axes[i].v;
+    return r;
+  }
+
+  OSSIA_INLINE void set_velocity(const std::array<float, N>& v) noexcept
+  {
+    for(std::size_t i = 0; i < N; i++)
+      axes[i].v = v[i];
+  }
+};
+
+/**
+ * @brief One candidate pairing for greedy bipartite assignment.
+ */
+struct match_candidate
+{
+  float cost;
+  std::int32_t track, det;
+};
+
+/**
+ * @brief Greedy bipartite matching: repeatedly take the cheapest remaining
+ * candidate whose track and detection are both still free.
+ *
+ * The candidate list is sorted in place (stable, so ties keep insertion order
+ * and results are deterministic). Not optimal like Hungarian, but within a
+ * fraction of it for tracking workloads (ByteTrack itself ships greedy variants)
+ * and O(K log K) with no allocation beyond the caller's buffers.
+ *
+ * @param candidates Gated candidate pairs; entries with an already-matched
+ *        track/detection are skipped.
+ * @param track_match Per-track matched detection index, -1 if unmatched.
+ *        Pre-filled entries (>= 0) are treated as taken.
+ * @param n_tracks Size of @p track_match.
+ * @param det_used Per-detection taken flag.
+ * @param n_dets Size of @p det_used.
+ */
+inline void greedy_assignment(
+    std::vector<match_candidate>& candidates, std::int32_t* track_match,
+    std::size_t n_tracks, char* det_used, std::size_t n_dets) noexcept
+{
+  std::stable_sort(
+      candidates.begin(), candidates.end(),
+      [](const match_candidate& a, const match_candidate& b) {
+    return a.cost < b.cost;
+  });
+  for(const auto& c : candidates)
+  {
+    if(c.track < 0 || std::size_t(c.track) >= n_tracks)
+      continue;
+    if(c.det < 0 || std::size_t(c.det) >= n_dets)
+      continue;
+    if(track_match[c.track] >= 0 || det_used[c.det])
+      continue;
+    track_match[c.track] = c.det;
+    det_used[c.det] = 1;
+  }
+}
+
+}

--- a/src/ossia_sources.cmake
+++ b/src/ossia_sources.cmake
@@ -76,6 +76,9 @@ set(API_HEADERS
     "${CMAKE_CURRENT_SOURCE_DIR}/ossia/detail/variant.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ossia/detail/yield.hpp"
 
+    "${CMAKE_CURRENT_SOURCE_DIR}/ossia/math/filters.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ossia/math/point_tracker.hpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ossia/math/tracking.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ossia/math/safe_math.hpp"
 #    "${CMAKE_CURRENT_SOURCE_DIR}/ossia/detail/instantiations.hpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ossia/misc_visitors.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 get_target_property(OSSIA_PROTOCOLS ossia OSSIA_PROTOCOLS)
 
 ### Tests ###
+ossia_add_test(SafeMathTest "${CMAKE_CURRENT_SOURCE_DIR}/Math/SafeMathTest.cpp")
+ossia_add_test(FiltersTest  "${CMAKE_CURRENT_SOURCE_DIR}/Math/FiltersTest.cpp")
 ossia_add_test(PresetTest   "${CMAKE_CURRENT_SOURCE_DIR}/Preset/PresetTest.cpp")
 ossia_add_test(CueTest      "${CMAKE_CURRENT_SOURCE_DIR}/Preset/CueTest.cpp")
 ossia_add_test(AddressTest  "${CMAKE_CURRENT_SOURCE_DIR}/Network/AddressTest.cpp")

--- a/tests/Dataflow/SoundTest.cpp
+++ b/tests/Dataflow/SoundTest.cpp
@@ -700,3 +700,127 @@ TEST_CASE("rubberband_drop_then_paste_sync", "[rubberband][sync]")
   rubberband_stretcher::s_prime_strategy = ps::BareRecipe;
 }
 #endif
+
+// Regression test: read_audio_from_buffer indexed the sample buffer without a
+// lower bound. When the transport crosses zero the computed read position goes
+// negative (the crash report showed start = -10096 with loops = true), and every
+// one of the five read paths would then index before the start of the sample.
+// A negative position must read as silence, never out of bounds.
+#include <ossia/dataflow/nodes/sound_utils.hpp>
+
+TEST_CASE("read_audio_from_buffer_negative_start", "[sound][regression]")
+{
+  using namespace ossia;
+
+  // A short ramp so any out-of-range read is obvious in the output.
+  constexpr int64_t len = 64;
+  std::vector<float> left(len), right(len);
+  for(int64_t i = 0; i < len; i++)
+  {
+    left[i] = 1.f + i;
+    right[i] = 101.f + i;
+  }
+
+  audio_span<float> data;
+  data.push_back(std::span<const float>(left.data(), len));
+  data.push_back(std::span<const float>(right.data(), len));
+
+  constexpr int64_t n = 16;
+  std::vector<float> out_l(n), out_r(n);
+  float* out[2] = {out_l.data(), out_r.data()};
+
+  const auto reset = [&] {
+    std::fill(out_l.begin(), out_l.end(), -1.f);
+    std::fill(out_r.begin(), out_r.end(), -1.f);
+  };
+
+  // Everything before sample 0 must be silence; everything at or after it must
+  // be the sample data, on both channels.
+  const auto check = [&](int64_t start, int64_t start_offset) {
+    for(int64_t k = 0; k < n; k++)
+    {
+      const int64_t pos = start + start_offset + k;
+      if(pos < 0 || pos >= len)
+      {
+        INFO("k=" << k << " pos=" << pos << " expected silence");
+        REQUIRE(out_l[k] == 0.f);
+        REQUIRE(out_r[k] == 0.f);
+      }
+      else
+      {
+        INFO("k=" << k << " pos=" << pos);
+        REQUIRE(out_l[k] == left[pos]);
+        REQUIRE(out_r[k] == right[pos]);
+      }
+    }
+  };
+
+  SECTION("no loop, fully before the start")
+  {
+    reset();
+    read_audio_from_buffer<float>(data, -100, n, 0, len, false, out);
+    check(-100, 0);
+  }
+
+  SECTION("no loop, straddling sample zero")
+  {
+    reset();
+    read_audio_from_buffer<float>(data, -8, n, 0, len, false, out);
+    check(-8, 0);
+  }
+
+  SECTION("no loop, straddling with a start offset")
+  {
+    reset();
+    read_audio_from_buffer<float>(data, -12, n, 4, len, false, out);
+    check(-12, 4);
+  }
+
+  SECTION("loop, fully before the start")
+  {
+    // The reported crash: loops = true and a large negative start took the
+    // "absolute best case" path, which checked only the upper bound.
+    reset();
+    read_audio_from_buffer<float>(data, -10096, n, 0, len, true, out);
+    for(int64_t k = 0; k < n; k++)
+    {
+      REQUIRE(out_l[k] == 0.f);
+      REQUIRE(out_r[k] == 0.f);
+    }
+  }
+
+  SECTION("loop, straddling sample zero")
+  {
+    reset();
+    read_audio_from_buffer<float>(data, -8, n, 0, len, true, out);
+    check(-8, 0);
+  }
+
+  SECTION("loop, negative start wrapping within the buffer")
+  {
+    // start + samples_to_write >= loop_duration takes the wrapping path, where
+    // the built-in % keeps the sign of a negative dividend.
+    reset();
+    const int64_t loop_duration = 8;
+    read_audio_from_buffer<float>(data, -3, n, 0, loop_duration, true, out);
+    for(int64_t k = 0; k < n; k++)
+    {
+      const int64_t raw = -3 + k;
+      const int64_t wrapped = ((raw % loop_duration) + loop_duration) % loop_duration;
+      REQUIRE(wrapped >= 0);
+      REQUIRE(out_l[k] == left[wrapped]);
+      REQUIRE(out_r[k] == right[wrapped]);
+    }
+  }
+
+  SECTION("forward reads are unchanged")
+  {
+    reset();
+    read_audio_from_buffer<float>(data, 4, n, 0, len, false, out);
+    check(4, 0);
+
+    reset();
+    read_audio_from_buffer<float>(data, 4, n, 0, len, true, out);
+    check(4, 0);
+  }
+}

--- a/tests/Editor/TimeIntervalTest.cpp
+++ b/tests/Editor/TimeIntervalTest.cpp
@@ -117,3 +117,148 @@ TEST_CASE("test_execution", "test_execution")
   //      interval->stop();
   //      std::this_thread::sleep_for(std::chrono::milliseconds(100));
 }
+
+#if defined(OSSIA_SCENARIO_DATAFLOW)
+#include <ossia/dataflow/nodes/forward_node.hpp>
+
+// Regression test: the interval node's Speed inlet (m_inlets[2]) used to be
+// allocated, registered and serialized but read by nobody - writing to it was
+// a silent no-op. A value written there must now scale the observed tick rate.
+TEST_CASE("speed_inlet_override", "speed_inlet_override")
+{
+  root_scenario s;
+
+  const auto req = [] {
+    ossia::token_request req;
+    req.prev_date = ossia::time_value{};
+    req.date = ossia::time_value{};
+    req.tempo = 120;
+    req.speed = 1.;
+    req.signature = {4, 4};
+    return req;
+  }();
+
+  // Neutral constant tempo curve at the root tempo, so that the only rate
+  // factor under test is the speed override itself.
+  ossia::tempo_curve curve;
+  curve.set_x0(0);
+  curve.set_y0(120.);
+  s.interval->set_tempo_curve(curve);
+
+  auto node = static_cast<ossia::nodes::interval*>(s.interval->node.get());
+  REQUIRE(node->root_inputs().size() == 4);
+  REQUIRE(node->speed_override == ossia::nodes::interval::no_speed);
+  REQUIRE(s.interval->speed_override() == 1.);
+
+  s.interval->start();
+  s.interval->tick_current(ossia::time_value{}, {});
+
+  // Baseline: tempo = root tempo, no override: 1000 units advance 1000.
+  s.interval->tick(1000_tv, req);
+  REQUIRE(s.interval->get_date() == 1000_tv);
+  REQUIRE(s.interval->get_speed(s.interval->get_date()) == 1.);
+
+  // Write 2.0 into the Speed inlet, run the node as the graph would.
+  node->root_inputs()[2]->target<ossia::value_port>()->write_value(2.0f, 0);
+  node->run(ossia::token_request{}, ossia::exec_state_facade{});
+  REQUIRE(node->speed_override == 2.0f);
+  REQUIRE(s.interval->speed_override() == 2.);
+  REQUIRE(s.interval->get_speed(s.interval->get_date()) == 2.);
+
+  // The observed tick rate must double: this is the regression assertion.
+  s.interval->tick(1000_tv, req);
+  REQUIRE(s.interval->get_date() == 3000_tv);
+
+  // Half speed.
+  node->root_inputs()[2]->target<ossia::value_port>()->get_data().clear();
+  node->root_inputs()[2]->target<ossia::value_port>()->write_value(0.5f, 0);
+  node->run(ossia::token_request{}, ossia::exec_state_facade{});
+  REQUIRE(s.interval->get_speed(s.interval->get_date()) == 0.5);
+  s.interval->tick(1000_tv, req);
+  REQUIRE(s.interval->get_date() == 3500_tv);
+
+  // A non-finite value must be ignored, keeping the previous override.
+  node->root_inputs()[2]->target<ossia::value_port>()->get_data().clear();
+  node->root_inputs()[2]->target<ossia::value_port>()->write_value(
+      std::numeric_limits<float>::quiet_NaN(), 0);
+  node->run(ossia::token_request{}, ossia::exec_state_facade{});
+  REQUIRE(node->speed_override == 0.5f);
+
+  // local_time_factor must see it too (used by scenario children).
+  REQUIRE(s.interval->local_time_factor(req) == 0.5);
+}
+
+// Without a tempo curve the inlets do not exist and nothing changes.
+TEST_CASE("speed_inlet_absent_without_tempo", "speed_inlet_absent_without_tempo")
+{
+  root_scenario s;
+  auto node = static_cast<ossia::nodes::interval*>(s.interval->node.get());
+  REQUIRE(node->root_inputs().size() == 1);
+  REQUIRE(s.interval->get_speed(s.interval->get_date()) == 1.);
+
+  s.interval->start();
+  s.interval->tick_current(ossia::time_value{}, {});
+  ossia::token_request req;
+  req.tempo = 120;
+  req.speed = 1.;
+  s.interval->tick(1000_tv, req);
+  REQUIRE(s.interval->get_date() == 1000_tv);
+}
+
+// Regression test for the Tempo inlet (m_inlets[1]). This is the inlet that
+// has always worked; it is asserted here because the Speed inlet work added a
+// sibling read in the same block and nothing covered tempo propagation.
+TEST_CASE("tempo_inlet_propagates", "tempo_inlet_propagates")
+{
+  root_scenario s;
+
+  const auto req = [] {
+    ossia::token_request req;
+    req.prev_date = ossia::time_value{};
+    req.date = ossia::time_value{};
+    req.tempo = 120;
+    req.speed = 1.;
+    req.signature = {4, 4};
+    return req;
+  }();
+
+  ossia::tempo_curve curve;
+  curve.set_x0(0);
+  curve.set_y0(120.);
+  s.interval->set_tempo_curve(curve);
+
+  auto node = static_cast<ossia::nodes::interval*>(s.interval->node.get());
+  REQUIRE(node->root_inputs().size() == 4);
+  REQUIRE(node->tempo == ossia::nodes::interval::no_tempo);
+
+  s.interval->start();
+  s.interval->tick_current(ossia::time_value{}, {});
+
+  // Baseline: curve says 120 == root_tempo, so rate is 1.
+  REQUIRE(s.interval->get_speed(s.interval->get_date()) == 1.);
+  s.interval->tick(1000_tv, req);
+  REQUIRE(s.interval->get_date() == 1000_tv);
+
+  // Write 240 BPM into the Tempo inlet: the live value must override the curve.
+  node->root_inputs()[1]->target<ossia::value_port>()->write_value(240.0f, 0);
+  node->run(ossia::token_request{}, ossia::exec_state_facade{});
+  REQUIRE(node->tempo == 240.0f);
+  REQUIRE(s.interval->get_speed(s.interval->get_date()) == 2.);
+
+  // and the observed tick rate must double
+  s.interval->tick(1000_tv, req);
+  REQUIRE(s.interval->get_date() == 3000_tv);
+
+  // 60 BPM -> half rate
+  node->root_inputs()[1]->target<ossia::value_port>()->get_data().clear();
+  node->root_inputs()[1]->target<ossia::value_port>()->write_value(60.0f, 0);
+  node->run(ossia::token_request{}, ossia::exec_state_facade{});
+  REQUIRE(node->tempo == 60.0f);
+  REQUIRE(s.interval->get_speed(s.interval->get_date()) == 0.5);
+  s.interval->tick(1000_tv, req);
+  REQUIRE(s.interval->get_date() == 3500_tv);
+
+  // local_time_factor must agree
+  REQUIRE(s.interval->local_time_factor(req) == 0.5);
+}
+#endif

--- a/tests/Math/FiltersTest.cpp
+++ b/tests/Math/FiltersTest.cpp
@@ -1,0 +1,169 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check it.
+// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+// The smoothing primitives. These are shared by every tracker and mapping in
+// the tree, so the properties asserted here are the ones callers rely on
+// without checking: that the first sample is not smoothed up from zero, that a
+// filter converges to a constant input, that alpha = 1 is a pass-through, and
+// that an angle filter does not lurch by a full turn at the wrap.
+
+#include <ossia/detail/config.hpp>
+#include <ossia/math/filters.hpp>
+
+#include "include_catch.hpp"
+
+#include <cmath>
+
+TEST_CASE("lowpass_alpha and lag_alpha are in range and monotonic", "filters")
+{
+  // Both map a cutoff/time-constant and a dt to a coefficient in [0, 1].
+  for(float dt : {1.f / 44100.f, 1.f / 60.f, 0.1f, 1.f})
+  {
+    for(float cutoff : {0.01f, 1.f, 20.f, 1000.f})
+    {
+      const float a = ossia::lowpass_alpha(cutoff, dt);
+      INFO("cutoff " << cutoff << " dt " << dt << " -> " << a);
+      REQUIRE(a >= 0.f);
+      REQUIRE(a <= 1.f);
+    }
+    // A longer time constant smooths harder, i.e. a smaller coefficient.
+    REQUIRE(ossia::lag_alpha(1.f, dt) < ossia::lag_alpha(0.01f, dt));
+  }
+}
+
+TEST_CASE("one_pole passes the first sample through", "filters")
+{
+  // The point of the primed flag: starting from a default-constructed zero
+  // would make every filter open with a ramp from silence that the signal
+  // never contained.
+  ossia::one_pole_filter<float> f;
+  REQUIRE(f(5.f, 0.1f) == Catch::Approx(5.f));
+  // The second sample is smoothed, so it lands between the two.
+  const float y = f(10.f, 0.5f);
+  REQUIRE(y > 5.f);
+  REQUIRE(y < 10.f);
+}
+
+TEST_CASE("one_pole converges to a constant input", "filters")
+{
+  ossia::one_pole_filter<float> f;
+  f(0.f, 0.2f);
+  for(int i = 0; i < 500; i++)
+    f(1.f, 0.2f);
+  REQUIRE(f.y == Catch::Approx(1.f).margin(1e-4));
+}
+
+TEST_CASE("one_pole alpha extremes", "filters")
+{
+  // alpha = 1 is a pass-through; alpha = 0 freezes. Callers derive alpha from
+  // dt, which can legitimately reach either end when a source stalls or fires
+  // twice in a row.
+  ossia::one_pole_filter<float> pass;
+  pass(0.f, 1.f);
+  REQUIRE(pass(7.f, 1.f) == Catch::Approx(7.f));
+
+  ossia::one_pole_filter<float> frozen;
+  frozen(3.f, 1.f);
+  REQUIRE(frozen(99.f, 0.f) == Catch::Approx(3.f));
+}
+
+TEST_CASE("one_pole reset", "filters")
+{
+  ossia::one_pole_filter<float> f;
+  f(1.f, 0.5f);
+  f.reset();
+  // Unprimed again: the next sample passes through rather than being smoothed
+  // towards from the old state.
+  REQUIRE(f(42.f, 0.01f) == Catch::Approx(42.f));
+
+  f.reset(10.f);
+  REQUIRE(f.y == Catch::Approx(10.f));
+  REQUIRE(f(10.f, 0.5f) == Catch::Approx(10.f));
+}
+
+TEST_CASE("one_euro is smoother at rest than in motion", "filters")
+{
+  // The whole point of the filter: the cutoff rises with speed, so jitter at
+  // rest is attenuated much more than a genuine fast movement is.
+  const double dt = 1. / 60.;
+
+  ossia::one_euro_filter<float> still;
+  ossia::one_euro_filter<float> moving;
+
+  float out_still = 0.f, out_moving = 0.f;
+  for(int i = 0; i < 120; i++)
+  {
+    const float jitter = (i % 2) ? 0.01f : -0.01f;
+    out_still = still(jitter, dt);
+    out_moving = moving(float(i) * 0.1f + jitter, dt);
+  }
+
+  // At rest the alternating input is squashed towards its mean.
+  REQUIRE(std::abs(out_still) < 0.01f);
+  // While moving it tracks the ramp instead of lagging far behind it.
+  REQUIRE(out_moving > 10.f);
+}
+
+TEST_CASE("one_euro tolerates a non-positive dt", "filters")
+{
+  // Sources do repeat a timestamp - two OSC bundles in one frame, a stalled
+  // camera - and dividing by that dt would produce an infinity that then
+  // poisons the state permanently.
+  ossia::one_euro_filter<float> f;
+  f(1.f, 1. / 60.);
+  const float held = f(2.f, 0.);
+  REQUIRE(std::isfinite(held));
+  const float next = f(2.f, 1. / 60.);
+  REQUIRE(std::isfinite(next));
+}
+
+TEST_CASE("moving_average over its window", "filters")
+{
+  ossia::moving_average_filter<float, 4> f;
+  // Filled with a constant, the average is that constant - the O(1) running
+  // sum must not drift as samples are evicted.
+  for(int i = 0; i < 50; i++)
+    f(2.f);
+  REQUIRE(f(2.f) == Catch::Approx(2.f));
+
+  // A step of the same width as the window is fully absorbed after N samples.
+  ossia::moving_average_filter<float, 4> g;
+  for(int i = 0; i < 8; i++)
+    g(0.f);
+  float y{};
+  for(int i = 0; i < 4; i++)
+    y = g(4.f);
+  REQUIRE(y == Catch::Approx(4.f));
+}
+
+TEST_CASE("median rejects an isolated outlier", "filters")
+{
+  // The reason to use a median rather than an average: one bad sample from a
+  // detector should not move the output at all.
+  ossia::median_filter<float, 5> f;
+  for(int i = 0; i < 5; i++)
+    f(1.f);
+  REQUIRE(f(1000.f) == Catch::Approx(1.f));
+  REQUIRE(f(1.f) == Catch::Approx(1.f));
+}
+
+TEST_CASE("unwrap_angle does not lurch across the discontinuity", "filters")
+{
+  const auto pi_v = float(ossia::pi);
+
+  // Just past +pi, the naive value jumps by -2pi; unwrapped against the
+  // previous value it continues upward instead.
+  const float prev = pi_v - 0.1f;
+  const float wrapped = -pi_v + 0.1f; // same motion, wrapped
+  const float unwrapped = ossia::unwrap_angle(wrapped, prev);
+  REQUIRE(unwrapped > prev);
+  REQUIRE(unwrapped == Catch::Approx(prev + 0.2f).margin(1e-4));
+
+  // And it is idempotent for a value already near the reference.
+  REQUIRE(ossia::unwrap_angle(0.5f, 0.4f) == Catch::Approx(0.5f).margin(1e-5));
+
+  // Several turns away still lands one turn from the reference.
+  // (not named `far`: that is still a macro in the Windows headers)
+  const float many_turns = ossia::unwrap_angle(0.2f + 6.f * pi_v, 0.2f);
+  REQUIRE(many_turns == Catch::Approx(0.2f).margin(1e-3));
+}

--- a/tests/Math/SafeMathTest.cpp
+++ b/tests/Math/SafeMathTest.cpp
@@ -1,0 +1,124 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check it.
+// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+// safe_isnan / safe_isinf / safe_isfinite exist because -ffast-math lets the
+// compiler assume no NaN and no infinity ever occur, so it folds std::isnan and
+// std::isinf to a constant 0 and std::isfinite to a constant 1. A check written
+// with them then disappears entirely, and the value it was guarding against
+// flows on. These assert the predicates keep answering truthfully, which is the
+// whole reason the file exists - and they are worth running under the same
+// flags the library ships with.
+
+#include <ossia/detail/config.hpp>
+#include <ossia/math/safe_math.hpp>
+
+#include "include_catch.hpp"
+
+#include <limits>
+
+namespace
+{
+constexpr auto qnan = std::numeric_limits<double>::quiet_NaN();
+constexpr auto snan = std::numeric_limits<double>::signaling_NaN();
+constexpr auto inf = std::numeric_limits<double>::infinity();
+constexpr auto dmax = std::numeric_limits<double>::max();
+constexpr auto dmin = std::numeric_limits<double>::min();
+constexpr auto denorm = std::numeric_limits<double>::denorm_min();
+}
+
+TEST_CASE("safe_isnan", "safe_math")
+{
+  REQUIRE(ossia::safe_isnan(qnan));
+  REQUIRE(ossia::safe_isnan(snan));
+  REQUIRE(ossia::safe_isnan(-qnan));
+
+  REQUIRE(!ossia::safe_isnan(0.));
+  REQUIRE(!ossia::safe_isnan(-0.));
+  REQUIRE(!ossia::safe_isnan(1.));
+  REQUIRE(!ossia::safe_isnan(-1.));
+  REQUIRE(!ossia::safe_isnan(inf));
+  REQUIRE(!ossia::safe_isnan(-inf));
+  REQUIRE(!ossia::safe_isnan(dmax));
+  REQUIRE(!ossia::safe_isnan(dmin));
+  REQUIRE(!ossia::safe_isnan(denorm));
+}
+
+TEST_CASE("safe_isinf", "safe_math")
+{
+  REQUIRE(ossia::safe_isinf(inf));
+  REQUIRE(ossia::safe_isinf(-inf));
+
+  REQUIRE(!ossia::safe_isinf(0.));
+  REQUIRE(!ossia::safe_isinf(-0.));
+  REQUIRE(!ossia::safe_isinf(1.));
+  REQUIRE(!ossia::safe_isinf(qnan));
+  // The largest finite double is not infinity, and the bit patterns are
+  // adjacent - the obvious off-by-one in an exponent test shows up here.
+  REQUIRE(!ossia::safe_isinf(dmax));
+  REQUIRE(!ossia::safe_isinf(-dmax));
+  REQUIRE(!ossia::safe_isinf(denorm));
+}
+
+TEST_CASE("safe_isfinite", "safe_math")
+{
+  REQUIRE(ossia::safe_isfinite(0.));
+  REQUIRE(ossia::safe_isfinite(-0.));
+  REQUIRE(ossia::safe_isfinite(1.));
+  REQUIRE(ossia::safe_isfinite(-1.));
+  REQUIRE(ossia::safe_isfinite(dmax));
+  REQUIRE(ossia::safe_isfinite(-dmax));
+  REQUIRE(ossia::safe_isfinite(dmin));
+  // Subnormals are finite. An implementation testing "exponent is zero" for
+  // something other than what it means would get this wrong.
+  REQUIRE(ossia::safe_isfinite(denorm));
+  REQUIRE(ossia::safe_isfinite(-denorm));
+
+  REQUIRE(!ossia::safe_isfinite(qnan));
+  REQUIRE(!ossia::safe_isfinite(snan));
+  REQUIRE(!ossia::safe_isfinite(-qnan));
+  REQUIRE(!ossia::safe_isfinite(inf));
+  REQUIRE(!ossia::safe_isfinite(-inf));
+}
+
+TEST_CASE("safe predicates agree with each other", "safe_math")
+{
+  // isfinite is exactly "neither NaN nor infinity". Asserting the identity
+  // rather than a list of cases catches a divergence between the three
+  // platform-specific branches.
+  const double values[] = {0.,   -0.,   1.,   -1.,  0.5,  -0.5, dmax,   -dmax,
+                           dmin, denorm, -denorm, inf, -inf, qnan, snan, -qnan};
+  for(double v : values)
+  {
+    INFO("value: " << v);
+    REQUIRE(
+        ossia::safe_isfinite(v) == (!ossia::safe_isnan(v) && !ossia::safe_isinf(v)));
+    // A value is never two of the three things at once.
+    REQUIRE(!(ossia::safe_isnan(v) && ossia::safe_isinf(v)));
+  }
+}
+
+TEST_CASE("safe predicates survive arithmetic that produces them", "safe_math")
+{
+  // Values the compiler cannot constant-fold away: these come out of real
+  // arithmetic, which is how they arise in a running graph.
+  volatile double zero = 0.;
+  volatile double one = 1.;
+  volatile double big = dmax;
+
+  const double div = one / zero;
+  REQUIRE(ossia::safe_isinf(div));
+  REQUIRE(!ossia::safe_isfinite(div));
+
+  const double nan_from_div = zero / zero;
+  REQUIRE(ossia::safe_isnan(nan_from_div));
+  REQUIRE(!ossia::safe_isfinite(nan_from_div));
+
+  const double overflowed = big * big;
+  REQUIRE(ossia::safe_isinf(overflowed));
+  REQUIRE(!ossia::safe_isfinite(overflowed));
+
+  const double ordinary = one / (one + one);
+  REQUIRE(ossia::safe_isfinite(ordinary));
+  REQUIRE(!ossia::safe_isnan(ordinary));
+  REQUIRE(!ossia::safe_isinf(ordinary));
+}


### PR DESCRIPTION
Groundwork for a point tracker and a beat tracker in score, plus the bugs that surfaced while building them.

### New: shared analysis primitives

- **`math/filters.hpp`** — consolidates smoothing that had been reimplemented at each call site: one-pole, one-euro, moving average, median, and the angle unwrap that makes a wrapping signal safe to filter at all. The one-euro takes its derivative against the previous *raw* input, as in Casiez/Roussel/Vogel's reference implementation, where several of the copies differentiated against the previous *filtered* value.
- **`math/tracking.hpp`** — the layer under any multi-object tracker: a dt-correct scalar position/velocity Kalman filter, its N-dimensional composition, and greedy bipartite assignment. A constant-velocity model with independent axes decouples exactly into one two-state filter per axis, so the full 2Nx2N filter is mathematically identical to N of these — no matrix library needed.
- **`math/point_tracker.hpp`** — a full tracker on top: two-stage association, direction consistency, confidence modelling, coasting, revival, slot allocation.

Everything takes an explicit dt. These run off cameras, OSC and TUIO, whose frame spacing is neither fixed nor known ahead of time.

### Fixes

**`read_audio_from_buffer` crashed on a negative read position.** All five paths clamped against the end of the file and none against its start. Reachable by dragging a sound file across the origin in an interval whose tempo takes its date below zero. The loop path had a second form of it: a C++ modulo of a negative dividend is negative, so wrapping produced a negative position rather than a wrapped one. The regression test fails on the previous revision.

**An interval with a tempo but no signature inherited the parent's musical position.** So inside one interval, processes reading musical time (Patternist) followed the parent clock while processes reading the date (a sound file) followed the local tempo — and which one a process obeyed looked arbitrary. Tempo alone is now enough to establish a local position.

**The vendored Steinberg ASIO SDK stops compiling under `WIN32_LEAN_AND_MEAN`.** `iasiodrv.h` declares `IASIO` with the `interface` keyword, a macro reached only via `<ole2.h>` — which is exactly what that define cuts out. libossia's own build never sets it, so this only appears once libossia is built inside score, which sets it globally for all C++. Undone for that target alone.

This one is latent on `master` today: the submodule still tracks a fork carrying a patch that adds `<windows.h>` and `<unknwn.h>` to `iasiodrv.h`. It becomes load-bearing the moment the retrack to upstream `audiosdk/asio` lands. Verified on clang64 against the genuine upstream headers with the exact command line CMake generates — fails without the flag, passes with it.

### Riding along

`math_expression`: `has_variable` now answers lexically, so it works for an expression that did not compile — which is usually when a caller wants to ask. Adds `valid()` to distinguish "compiled, no such variable" from "did not compile".

### Note

Deliberately **not** included: a local variant of the Boost.Asio separate-compilation fix. `a78bc89a8` already solves it on master, more cleanly, and this branch is based on it. Unrelated to the Steinberg ASIO change above despite the name collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnNVzm2dPA5iHbSYKrpzZj