### PR TITLE
Full-scale samples wrapped to the opposite polarity at 24 and 32 bits

### DIFF
--- a/src/ossia/dataflow/float_to_sample.hpp
+++ b/src/ossia/dataflow/float_to_sample.hpp
@@ -58,31 +58,25 @@ constexpr int16_t float_to_sample<int16_t, 16>(ossia::audio_sample sample) noexc
 
 // ALSA S24_LE: https://stackoverflow.com/a/40301874/1495627
 template <>
-constexpr int32_t float_to_sample<int32_t, 24>(ossia::audio_sample sample) noexcept
+constexpr int32_t float_to_sample<int32_t, 24>(ossia::audio_sample x) noexcept
 {
-  const constexpr ossia::audio_sample int24_max
-      = std::numeric_limits<int32_t>::max() / 256.;
-  return int32_t(sample * int24_max);
-}
-
-/*
-template <>
-constexpr int32_t float_to_sample<int32_t, 24>(audio_sample x) noexcept
-{
-  // TODO division -> multiplication
   if constexpr(std::is_same_v<ossia::audio_sample, float>)
   {
     return (x * (0x7FFFFF + 0.5f)) - 0.5f;
   }
   else
+  {
     return (x * (0x7FFFFF + 0.5)) - 0.5;
+  }
 }
-*/
 
 template <>
 constexpr int32_t float_to_sample<int32_t, 32>(audio_sample x) noexcept
 {
-  return x * (audio_sample)std::numeric_limits<int32_t>::max();
+  // In double even when the samples are float: 0x7FFFFFFF + 0.5 is not
+  // representable as a float and rounds to 2^31, which +1.0 then converts out
+  // of int32_t's range.
+  return (double(x) * (0x7FFFFFFF + 0.5)) - 0.5;
 }
 
 template <>


### PR DESCRIPTION
`float_to_sample<int32_t, 32>` multiplied by `(float)INT32_MAX`. That constant rounds **up** to `2147483648.0f` — one past the largest representable int32 — so converting `1.0f` was out of range, and on x86-64 `cvttss2si` returns the integer indefinite value, `INT32_MIN`.

**A full-scale positive peak was written as a full-scale negative one** in every `AV_SAMPLE_FMT_S32` / `S32P` stream, which is what libav's 24- and 32-bit PCM encoders take. `-1.0` was already correct, so it is a polarity flip on one endpoint — an audible click at exactly the loudest sample. UBSan flags it independently at `float_to_sample.hpp:85`.

The 24-bit form had the same shape: `int24_max` is `INT32_MAX / 256.0 == 8388607.99609375`, which as a float rounds up to 2²³, so `1.0` quantised to `8388608`, one past the largest signed 24-bit value.

### The fix

Both now use the mapping the **16-bit specialisation directly beside them already used**, `x * (max + 0.5) - 0.5`, which lands both endpoints exactly. Worth noting the correct 24-bit form was already in this file — commented out, immediately above the one that was live.

At 32 bits that expression has to be evaluated in `double` even when `audio_sample` is `float`, because `0x7FFFFFFF + 0.5` is not representable as a float and rounds to 2³¹ — which is the original bug in a new place.

### Verification

Checked at both endpoints and at quarter/half scale, against the convention the 16-bit case already encodes (positives one below the symmetric scale, negatives unchanged):

| level | s16 (unchanged) | s24 | s32 |
|---|---|---|---|
| +1.0 | 32767 | 8388607 | 2147483647 |
| −1.0 | −32768 | −8388608 | −2147483648 |
| +0.25 | 8191 | 2097151 | 536870911 |
| −0.25 | −8192 | −2097152 | −536870912 |

Found by a new encoder test suite in [ossia/score](https://github.com/ossia/score) covering all ten `AudioFrameEncoder` forms; it is green at 337 assertions with this change.
