### PR TITLE
Fix QML BLE: link Qt Bluetooth, expose service callbacks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 if(OSSIA_QT)
   find_package(${QT_VERSION} QUIET ${OSSIA_QT_REQUIRED} COMPONENTS Core)
-  find_package(${QT_VERSION} QUIET OPTIONAL_COMPONENTS Gui Qml NetworkAuth)
+  find_package(${QT_VERSION} QUIET OPTIONAL_COMPONENTS Gui Qml NetworkAuth Bluetooth Nfc)
 
   if(TARGET Qt::Core)
     set(QT_VERSION_MAJOR "")

--- a/src/ossia-qt/protocols/qml_bluetooth.hpp
+++ b/src/ossia-qt/protocols/qml_bluetooth.hpp
@@ -3,6 +3,8 @@
 #if __has_include(<QBluetoothDeviceDiscoveryAgent>)
 #define OSSIA_HAS_BLUETOOTH 1
 
+#include <ossia/detail/logger.hpp>
+
 #include <ossia-qt/protocols/utils.hpp>
 
 #include <QBluetoothDeviceDiscoveryAgent>
@@ -389,25 +391,30 @@ public:
   void readCharacteristic(QString uuid)
   {
     auto c = m_service->characteristic(bleUuidFromString(uuid));
-    if(c.isValid())
-      m_service->readCharacteristic(c);
+    if(!c.isValid())
+      return report(QStringLiteral("no such characteristic: %1").arg(uuid));
+    m_service->readCharacteristic(c);
   }
   W_SLOT(readCharacteristic)
 
   void writeCharacteristic(QString uuid, QByteArray value)
   {
     auto c = m_service->characteristic(bleUuidFromString(uuid));
-    if(c.isValid())
-      m_service->writeCharacteristic(c, value);
+    if(!c.isValid())
+      return report(QStringLiteral("no such characteristic: %1").arg(uuid));
+    m_service->writeCharacteristic(c, value);
   }
   W_SLOT(writeCharacteristic)
 
   void writeCharacteristicNoResponse(QString uuid, QByteArray value)
   {
     auto c = m_service->characteristic(bleUuidFromString(uuid));
-    if(c.isValid())
-      m_service->writeCharacteristic(
-          c, value, QLowEnergyService::WriteWithoutResponse);
+    if(!c.isValid())
+      return report(QStringLiteral("no such characteristic: %1").arg(uuid));
+    if(!c.properties().testFlag(QLowEnergyCharacteristic::WriteNoResponse))
+      report(QStringLiteral("%1 does not advertise WriteNoResponse").arg(uuid));
+    m_service->writeCharacteristic(
+        c, value, QLowEnergyService::WriteWithoutResponse);
   }
   W_SLOT(writeCharacteristicNoResponse)
 
@@ -415,10 +422,13 @@ public:
   {
     auto c = m_service->characteristic(bleUuidFromString(uuid));
     if(!c.isValid())
-      return;
+      return report(QStringLiteral("no such characteristic: %1").arg(uuid));
     auto cccd = c.clientCharacteristicConfiguration();
     if(!cccd.isValid())
-      return;
+      return report(QStringLiteral(
+                        "%1 has no CCCD descriptor; discoverDetails() must "
+                        "have completed before subscribing")
+                        .arg(uuid));
 
     if(c.properties().testFlag(QLowEnergyCharacteristic::Indicate))
       m_service->writeDescriptor(
@@ -433,7 +443,7 @@ public:
   {
     auto c = m_service->characteristic(bleUuidFromString(uuid));
     if(!c.isValid())
-      return;
+      return report(QStringLiteral("no such characteristic: %1").arg(uuid));
     auto cccd = c.clientCharacteristicConfiguration();
     if(cccd.isValid())
       m_service->writeDescriptor(cccd, QLowEnergyCharacteristic::CCCDDisable);
@@ -446,7 +456,20 @@ public:
   QJSValue onCharacteristicChanged;
   QJSValue onError;
 
+  W_PROPERTY(QJSValue, onDetailsDiscovered MEMBER onDetailsDiscovered)
+  W_PROPERTY(QJSValue, onCharacteristicRead MEMBER onCharacteristicRead)
+  W_PROPERTY(QJSValue, onCharacteristicWritten MEMBER onCharacteristicWritten)
+  W_PROPERTY(QJSValue, onCharacteristicChanged MEMBER onCharacteristicChanged)
+  W_PROPERTY(QJSValue, onError MEMBER onError)
+
 private:
+  void report(const QString& msg)
+  {
+    ossia::logger().error("BLE service: {}", msg.toStdString());
+    if(onError.isCallable())
+      onError.call({msg});
+  }
+
   QLowEnergyService* m_service{};
 };
 

--- a/src/ossia_features.cmake
+++ b/src/ossia_features.cmake
@@ -209,6 +209,13 @@ if(OSSIA_QT)
       target_link_libraries(ossia PUBLIC "${QT_PREFIX}::NetworkAuth")
     endif()
 
+    if(TARGET "${QT_PREFIX}::Bluetooth")
+      target_link_libraries(ossia PUBLIC "${QT_PREFIX}::Bluetooth")
+    endif()
+    if(TARGET "${QT_PREFIX}::Nfc")
+      target_link_libraries(ossia PUBLIC "${QT_PREFIX}::Nfc")
+    endif()
+
     add_custom_target(ossia-qml-sources SOURCES ${OSSIA_QML_SRCS})
     if(OSSIA_DISABLE_QT_PLUGIN)
       target_compile_definitions(ossia PRIVATE OSSIA_DISABLE_QT_PLUGIN)


### PR DESCRIPTION
`Protocols.bluetoothScanner()` returns `null` in every build, and even past that a connected BLE device never delivers a single notification. Two independent causes, one per commit.

## 1. Qt Bluetooth/Nfc were never linked

`qml_bluetooth.hpp` and `qml_nfc.hpp` gate their whole implementation on `__has_include(<QBluetoothDeviceDiscoveryAgent>)` / `<QNearFieldManager>`, defining `OSSIA_HAS_BLUETOOTH` / `OSSIA_HAS_NFC`. But `src/CMakeLists.txt` only ever searched for `Gui Qml NetworkAuth`, so those modules' include directories never reached the `ossia` target, the guards were always false, and `qml_protocols.cpp` compiled the fallback stubs:

```cpp
QObject* qml_protocols::bluetoothScanner(QJSValue) { return nullptr; }
```

This was unconditional — it did not matter whether Qt Bluetooth was installed. On a build with Qt Bluetooth present in the SDK, `nm libossia.a` showed `bluetoothScanner(QJSValue)` present and **zero** `qml_bluetooth_scanner` symbols.

Unlike the SocketCAN stub just above it, which logs and invokes `onError`, these return a bare `nullptr`, so script sees only a `TypeError` on the next line.

## 2. `qml_ble_service` callbacks were invisible to the meta-object system

`qml_bluetooth_scanner` and `qml_ble_controller` are built from a config object, so their callbacks are assigned from C++ in the factory and work. A service is different — script gets it from `controller.service()` and assigns the callbacks itself:

```js
museSvc.onDetailsDiscovered     = function(chars) { ... }
museSvc.onCharacteristicChanged = function(uuid, value) { ... }
```

Those five members had no `W_PROPERTY`, so the assignments landed on the JS wrapper and never reached C++. `onDetailsDiscovered.isCallable()` stayed false, nothing was ever subscribed, and `onCharacteristicChanged` was equally dead. The device connects, then sits silent, with nothing logged anywhere.

Also gives the service methods a diagnostic path: `enableNotifications()`, `readCharacteristic()`, `writeCharacteristic()`, `writeCharacteristicNoResponse()` and `disableNotifications()` all returned silently on an unknown characteristic or a missing CCCD — the two failure modes a script cannot distinguish from a device that simply sends nothing.

## Testing

Found while bringing a Muse EEG headband up as a QML device tree on macOS (aarch64, static Qt 6). After both commits: scanner is created, the headband is discovered and connected, service details are discovered, all 12 characteristics subscribe, and EEG/PPG/accelerometer/gyroscope/battery notifications stream into the device tree.

Only verified on macOS. The CMake change is platform-neutral and the NFC half of it is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)